### PR TITLE
remove .do suffixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ plugins/*
 *.settings
 *.classpath
 analyzers/**/.gitignore
+*/*/target

--- a/analyzers/CobasC111/src/oe/plugin/analyzer/CobasC111Menu.java
+++ b/analyzers/CobasC111/src/oe/plugin/analyzer/CobasC111Menu.java
@@ -35,10 +35,10 @@ public class CobasC111Menu extends MenuPlugin {
         menu.setPresentationOrder(9);
         // The id needs to be unique in the system
         menu.setElementId("cobasc111_analyzer_plugin");
-        // This will always be "/AnalyzerResults.do?type=<The name of the analyzer in
+        // This will always be "/AnalyzerResults?type=<The name of the analyzer in
         // the database as specified in then Analyzer class call to
         // addAnalyzerDatabaseParts(....)
-        menu.setActionURL("/AnalyzerResults.do?type=CobasC111Analyzer");
+        menu.setActionURL("/AnalyzerResults?type=CobasC111Analyzer");
         // The key used for the name of the analyzer on the menu. Should not already
         // exist in MessageResource.properties.
         menu.setDisplayKey("banner.menu.results.cobasc111analyzer");

--- a/analyzers/CobasIntegra400/src/oe/plugin/analyzer/CobasIntegra400Menu.java
+++ b/analyzers/CobasIntegra400/src/oe/plugin/analyzer/CobasIntegra400Menu.java
@@ -36,10 +36,10 @@ public class CobasIntegra400Menu extends MenuPlugin {
         menu.setPresentationOrder(6);
         // The id needs to be unique in the system
         menu.setElementId("CobasIntegra400_analyzer_plugin");
-        // This will always be "/AnalyzerResults.do?type=<The name of the analyzer in
+        // This will always be "/AnalyzerResults?type=<The name of the analyzer in
         // the database as specified in then Analyzer class call to
         // addAnalyzerDatabaseParts(....)
-        menu.setActionURL("/AnalyzerResults.do?type=CobasIntegra400");
+        menu.setActionURL("/AnalyzerResults?type=CobasIntegra400");
         // The key used for the name of the analyzer on the menu. Should not already
         // exist in MessageResource.properties.
         menu.setDisplayKey("banner.menu.results.CobasIntegra400");

--- a/analyzers/CobasTaqMan48DBS/src/oe/plugin/analyzer/TaqMan48DBSMenu.java
+++ b/analyzers/CobasTaqMan48DBS/src/oe/plugin/analyzer/TaqMan48DBSMenu.java
@@ -35,10 +35,10 @@ public class TaqMan48DBSMenu extends MenuPlugin {
         menu.setPresentationOrder(30);
         // The id needs to be unique in the system
         menu.setElementId("taqman48_dbs_analyzer_plugin");
-        // This will always be "/AnalyzerResults.do?type=<The name of the analyzer in
+        // This will always be "/AnalyzerResults?type=<The name of the analyzer in
         // the database as specified in then Analyzer class call to
         // addAnalyzerDatabaseParts(....)
-        menu.setActionURL("/AnalyzerResults.do?type=TaqMan48DBSAnalyzer");
+        menu.setActionURL("/AnalyzerResults?type=TaqMan48DBSAnalyzer");
         // The key used for the name of the analyzer on the menu. Should not already
         // exist in MessageResource.properties.
         menu.setDisplayKey("banner.menu.results.taqman48dbsanalyzer");

--- a/analyzers/FacsCalibur/src/oe/plugin/analyzer/FacsCaliburMenu.java
+++ b/analyzers/FacsCalibur/src/oe/plugin/analyzer/FacsCaliburMenu.java
@@ -36,10 +36,10 @@ public class FacsCaliburMenu extends MenuPlugin {
         menu.setPresentationOrder(6);
         // The id needs to be unique in the system
         menu.setElementId("FacsCalibur_analyzer_plugin");
-        // This will always be "/AnalyzerResults.do?type=<The name of the analyzer in
+        // This will always be "/AnalyzerResults?type=<The name of the analyzer in
         // the database as specified in then Analyzer class call to
         // addAnalyzerDatabaseParts(....)
-        menu.setActionURL("/AnalyzerResults.do?type=FacsCalibur");
+        menu.setActionURL("/AnalyzerResults?type=FacsCalibur");
         // The key used for the name of the analyzer on the menu. Should not already
         // exist in MessageResource.properties.
         menu.setDisplayKey("banner.menu.results.FacsCalibur");

--- a/analyzers/FacsCantoII/src/oe/plugin/analyzer/FacsCantoIIMenu.java
+++ b/analyzers/FacsCantoII/src/oe/plugin/analyzer/FacsCantoIIMenu.java
@@ -36,10 +36,10 @@ public class FacsCantoIIMenu extends MenuPlugin {
         menu.setPresentationOrder(6);
         // The id needs to be unique in the system
         menu.setElementId("FacsCantoII_analyzer_plugin");
-        // This will always be "/AnalyzerResults.do?type=<The name of the analyzer in
+        // This will always be "/AnalyzerResults?type=<The name of the analyzer in
         // the database as specified in then Analyzer class call to
         // addAnalyzerDatabaseParts(....)
-        menu.setActionURL("/AnalyzerResults.do?type=FacsCantoII");
+        menu.setActionURL("/AnalyzerResults?type=FacsCantoII");
         // The key used for the name of the analyzer on the menu. Should not already
         // exist in MessageResource.properties.
         menu.setDisplayKey("banner.menu.results.FacsCantoII");

--- a/analyzers/FacsPresto/src/oe/plugin/analyzer/FacsPrestoMenu.java
+++ b/analyzers/FacsPresto/src/oe/plugin/analyzer/FacsPrestoMenu.java
@@ -35,10 +35,10 @@ public class FacsPrestoMenu extends MenuPlugin {
         menu.setPresentationOrder(9);
         // The id needs to be unique in the system
         menu.setElementId("FacsPresto_analyzer_plugin");
-        // This will always be "/AnalyzerResults.do?type=<The name of the analyzer in
+        // This will always be "/AnalyzerResults?type=<The name of the analyzer in
         // the database as specified in then Analyzer class call to
         // addAnalyzerDatabaseParts(....)
-        menu.setActionURL("/AnalyzerResults.do?type=FacsPrestoAnalyzer");
+        menu.setActionURL("/AnalyzerResults?type=FacsPrestoAnalyzer");
         // The key used for the name of the analyzer on the menu. Should not already
         // exist in MessageResource.properties.
         menu.setDisplayKey("banner.menu.results.FacsPrestoanalyzer");

--- a/analyzers/Fully/src/oe/plugin/analyzer/FullyMenu.java
+++ b/analyzers/Fully/src/oe/plugin/analyzer/FullyMenu.java
@@ -35,10 +35,10 @@ public class FullyMenu extends MenuPlugin {
         menu.setPresentationOrder(50);
         // The id needs to be unique in the system
         menu.setElementId("Fully_analyzer_plugin");
-        // This will always be "/AnalyzerResults.do?type=<The name of the analyzer in
+        // This will always be "/AnalyzerResults?type=<The name of the analyzer in
         // the database as specified in then Analyzer class call to
         // addAnalyzerDatabaseParts(....)
-        menu.setActionURL("/AnalyzerResults.do?type=FullyAnalyzer");
+        menu.setActionURL("/AnalyzerResults?type=FullyAnalyzer");
         // The key used for the name of the analyzer on the menu. Should not already
         // exist in MessageResource.properties.
         menu.setDisplayKey("banner.menu.results.Fullyanalyzer");

--- a/analyzers/GeneXpert/src/main/java/oe/plugin/analyzer/GeneXpertMenu.java
+++ b/analyzers/GeneXpert/src/main/java/oe/plugin/analyzer/GeneXpertMenu.java
@@ -35,10 +35,10 @@ public class GeneXpertMenu extends MenuPlugin {
 		menu.setPresentationOrder(10);
         // The id needs to be unique in the system
 		menu.setElementId("genexpert_analyzer_plugin");
-        // This will always be "/AnalyzerResults.do?type=<The name of the analyzer in
+        // This will always be "/AnalyzerResults?type=<The name of the analyzer in
         // the database as specified in then Analyzer class call to
         // addAnalyzerDatabaseParts(....)
-		menu.setActionURL("/AnalyzerResults.do?type=GeneXpertAnalyzer");
+		menu.setActionURL("/AnalyzerResults?type=GeneXpertAnalyzer");
         // The key used for the name of the analyzer on the menu. Should not already
         // exist in MessageResource.properties.
 		menu.setDisplayKey("banner.menu.results.genexpertanalyzer");

--- a/analyzers/Mindray/src/main/java/oe/plugin/analyzer/MindrayMenu.java
+++ b/analyzers/Mindray/src/main/java/oe/plugin/analyzer/MindrayMenu.java
@@ -35,10 +35,10 @@ public class MindrayMenu extends MenuPlugin {
 		menu.setPresentationOrder(10);
         // The id needs to be unique in the system
 		menu.setElementId("mindray_analyzer_plugin");
-        // This will always be "/AnalyzerResults.do?type=<The name of the analyzer in
+        // This will always be "/AnalyzerResults?type=<The name of the analyzer in
         // the database as specified in then Analyzer class call to
         // addAnalyzerDatabaseParts(....)
-		menu.setActionURL("/AnalyzerResults.do?type=MindrayAnalyzer");
+		menu.setActionURL("/AnalyzerResults?type=MindrayAnalyzer");
         // The key used for the name of the analyzer on the menu. Should not already
         // exist in MessageResource.properties.
 		menu.setDisplayKey("banner.menu.results.mindrayanalyzer");

--- a/analyzers/QuantStudio3/src/oe/plugin/analyzer/QuantStudio3Menu.java
+++ b/analyzers/QuantStudio3/src/oe/plugin/analyzer/QuantStudio3Menu.java
@@ -35,10 +35,10 @@ public class QuantStudio3Menu extends MenuPlugin {
 		menu.setPresentationOrder(10);
         // The id needs to be unique in the system
 		menu.setElementId("quantstudio3_analyzer_plugin");
-        // This will always be "/AnalyzerResults.do?type=<The name of the analyzer in
+        // This will always be "/AnalyzerResults?type=<The name of the analyzer in
         // the database as specified in then Analyzer class call to
         // addAnalyzerDatabaseParts(....)
-		menu.setActionURL("/AnalyzerResults.do?type=QuantStudio3Analyzer");
+		menu.setActionURL("/AnalyzerResults?type=QuantStudio3Analyzer");
         // The key used for the name of the analyzer on the menu. Should not already
         // exist in MessageResource.properties.
 		menu.setDisplayKey("banner.menu.results.quantstudio3analyzer");
@@ -59,7 +59,7 @@ public class QuantStudio3Menu extends MenuPlugin {
 		menu.setPresentationOrder(10);
 		// The id needs to be unique in the system
 		menu.setElementId("ananlyzer_setup");
-		menu.setActionURL("/AnalyzerSetup.do");
+		menu.setActionURL("/AnalyzerSetup");
 		// The key used for the name of the analyzer on the menu. Should not already
 		// exist in MessageResource.properties.
 		menu.setDisplayKey("banner.menu.analyzer.setup");

--- a/analyzers/SysmeXT/src/oe/plugin/analyzer/SysmeXTMenu.java
+++ b/analyzers/SysmeXT/src/oe/plugin/analyzer/SysmeXTMenu.java
@@ -36,10 +36,10 @@ public class SysmeXTMenu extends MenuPlugin {
         menu.setPresentationOrder(6);
         // The id needs to be unique in the system
         menu.setElementId("SysmeXT_analyzer_plugin");
-        // This will always be "/AnalyzerResults.do?type=<The name of the analyzer in
+        // This will always be "/AnalyzerResults?type=<The name of the analyzer in
         // the database as specified in then Analyzer class call to
         // addAnalyzerDatabaseParts(....)
-        menu.setActionURL("/AnalyzerResults.do?type=SysmeXT");
+        menu.setActionURL("/AnalyzerResults?type=SysmeXT");
         // The key used for the name of the analyzer on the menu. Should not already
         // exist in MessageResource.properties.
         menu.setDisplayKey("banner.menu.results.SysmeXT");

--- a/analyzers/Sysmex2000i/src/oe/plugin/analyzer/SysmexMenu.java
+++ b/analyzers/Sysmex2000i/src/oe/plugin/analyzer/SysmexMenu.java
@@ -35,10 +35,10 @@ public class SysmexMenu extends MenuPlugin {
         menu.setPresentationOrder(5);
         // The id needs to be unique in the system
         menu.setElementId("sysmex_analyzer_plugin");
-        // This will always be "/AnalyzerResults.do?type=<The name of the analyzer in
+        // This will always be "/AnalyzerResults?type=<The name of the analyzer in
         // the database as specified in then Analyzer class call to
         // addAnalyzerDatabaseParts(....)
-        menu.setActionURL("/AnalyzerResults.do?type=SysmexAnalyzer");
+        menu.setActionURL("/AnalyzerResults?type=SysmexAnalyzer");
         // The key used for the name of the analyzer on the menu. Should not already
         // exist in MessageResource.properties.
         menu.setDisplayKey("banner.menu.results.sysmexanalyzer");

--- a/analyzers/SysmexXT4000i/src/oe/plugin/analyzer/SysmexXTMenu.java
+++ b/analyzers/SysmexXT4000i/src/oe/plugin/analyzer/SysmexXTMenu.java
@@ -35,10 +35,10 @@ public class SysmexXTMenu extends MenuPlugin {
         menu.setPresentationOrder(50);
         // The id needs to be unique in the system
         menu.setElementId("sysmex_xt_analyzer_plugin");
-        // This will always be "/AnalyzerResults.do?type=<The name of the analyzer in
+        // This will always be "/AnalyzerResults?type=<The name of the analyzer in
         // the database as specified in then Analyzer class call to
         // addAnalyzerDatabaseParts(....)
-        menu.setActionURL("/AnalyzerResults.do?type=SysmexXTAnalyzer");
+        menu.setActionURL("/AnalyzerResults?type=SysmexXTAnalyzer");
         // The key used for the name of the analyzer on the menu. Should not already
         // exist in MessageResource.properties.
         menu.setDisplayKey("banner.menu.results.sysmexxtanalyzer");

--- a/analyzers/weberAnalyzer/src/oe/plugin/analyzer/WeberMenu.java
+++ b/analyzers/weberAnalyzer/src/oe/plugin/analyzer/WeberMenu.java
@@ -33,7 +33,7 @@ public class WeberMenu extends MenuPlugin {
         menu.setParent(PluginMenuService.getInstance().getKnownMenu(KnownMenu.ANALYZER, "menu_results"));
         menu.setPresentationOrder(5);
         menu.setElementId("weber_analyzer_plugin");
-        menu.setActionURL("/AnalyzerResults.do?type=WeberAnalyzer");
+        menu.setActionURL("/AnalyzerResults?type=WeberAnalyzer");
         menu.setDisplayKey("banner.menu.results.weber");
         menu.setOpenInNewWindow(false);
 


### PR DESCRIPTION
remove  `.do ` suffixes . since all .do suffixes were removed from the controllers in OpenELIS in this [commit](https://github.com/I-TECH-UW/OpenELIS-Global-2/commit/93c0d77ac8de15bea1f944a630f107a888200719)