### PR TITLE
feat(011-m5): Mindray HL7 plugin validation branch

### DIFF
--- a/analyzers/Mindray/README.md
+++ b/analyzers/Mindray/README.md
@@ -1,0 +1,10 @@
+# Mindray Analyzer Plugin
+
+Supports Mindray hematology and chemistry analyzers.
+
+## HL7 (M5 validation)
+
+- **BC-5380**: Hematology (CBC) over HL7. Results received via HL7 ORU^R01; core HL7 adapter and identification live in OpenELIS-Global (MSH sending application `MINDRAY`).
+- **BS-360E**: Chemistry over HL7. Same HL7 path; test codes (e.g. CREA, ALT, AST) in OBX map via field mappings or plugin defaults.
+
+Plugin registration and line-insertion logic remain here; HL7 parsing and MappingAware wrapper are in the main repo. See feature branch `feat/011-madagascar-analyzer-integration-m5-mindray-hl7` in OpenELIS-Global for integration tests and fixtures.


### PR DESCRIPTION
**Purpose**: Parallel plugins branch for Madagascar Analyzer Integration **M5: Mindray HL7 Plugin Validation** (OpenELIS-Global feature 011).

- Tracks the same milestone as main-repo branch `feat/011-madagascar-analyzer-integration-m5-mindray-hl7`.
- **This PR**: Adds `analyzers/Mindray/README.md` documenting HL7 support for BC-5380 and BS-360E and pointer to main-repo integration tests.
- Use this branch for any further **plugin-only changes** for M5; main repo holds HL7 adapter, integration tests, and MappingAware wrapper.