### PR TITLE
fix: remove @Override from isGenericPlugin() for CI compatibility

### DIFF
--- a/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMAnalyzer.java
+++ b/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMAnalyzer.java
@@ -76,7 +76,6 @@ public class GenericASTMAnalyzer implements AnalyzerImporterPlugin {
    *
    * @return true (always succeeds - actual analyzer lookup happens in isTargetAnalyzer)
    */
-  @Override
   public boolean isGenericPlugin() {
     return true;
   }

--- a/analyzers/GenericHL7/src/main/java/org/openelisglobal/plugins/analyzer/generichl7/GenericHL7Analyzer.java
+++ b/analyzers/GenericHL7/src/main/java/org/openelisglobal/plugins/analyzer/generichl7/GenericHL7Analyzer.java
@@ -86,7 +86,6 @@ public class GenericHL7Analyzer implements AnalyzerImporterPlugin {
    *
    * @return true (always succeeds - actual analyzer lookup happens in isTargetAnalyzer)
    */
-  @Override
   public boolean isGenericPlugin() {
     return true;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <module>./analyzers/AbbottArchitect</module>
     <module>./analyzers/FluoroCyclerXT</module>
     <module>./analyzers/GenericASTM</module>
+    <module>./analyzers/GenericHL7</module>
     <module>./analyzers/StagoSTart4</module>
   </modules>
 


### PR DESCRIPTION
## Summary
- Remove `@Override` annotation from `isGenericPlugin()` in GenericASTMAnalyzer and GenericHL7Analyzer
- Add GenericHL7 module to `plugins/pom.xml` so it gets built by Maven

## Problem
CI build was failing with:
```
[ERROR] GenericASTMAnalyzer.java:[79,3] method does not override or implement a method from a supertype
```

The plugins compile against published artifact `openelisglobal:3.2.1.2` which doesn't include the `isGenericPlugin()` default method in `AnalyzerImporterPlugin` interface yet.

## Solution
Remove the `@Override` annotation. This allows compilation while still satisfying the interface contract at runtime when the newer interface is loaded.

## Test plan
- [x] `mvn clean compile` succeeds for all 45 plugin modules
- [x] Both GenericASTM and GenericHL7 compile successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)