### PR TITLE
fix(011): adapt GenericASTM + GenericHL7 plugins to 2-table model

### DIFF
--- a/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMAnalyzer.java
+++ b/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMAnalyzer.java
@@ -15,8 +15,8 @@ package org.openelisglobal.plugins.analyzer.genericastm;
 
 import java.util.List;
 import java.util.Optional;
-import org.openelisglobal.analyzer.service.AnalyzerConfigurationService;
-import org.openelisglobal.analyzer.valueholder.AnalyzerConfiguration;
+import org.openelisglobal.analyzer.service.AnalyzerService;
+import org.openelisglobal.analyzer.valueholder.Analyzer;
 import org.openelisglobal.analyzerimport.analyzerreaders.AnalyzerLineInserter;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.services.PluginAnalyzerService;
@@ -32,7 +32,7 @@ import org.openelisglobal.spring.util.SpringContext;
  * test mappings, this generic plugin:
  *
  * <ul>
- *   <li>Reads identifier patterns from analyzer_configuration.identifier_pattern
+ *   <li>Reads identifier patterns from analyzer.identifier_pattern (2-table model)
  *   <li>Matches incoming ASTM messages against those patterns
  *   <li>Loads test mappings from analyzer_test_mapping table (configured via 004 Dashboard)
  * </ul>
@@ -55,13 +55,13 @@ public class GenericASTMAnalyzer implements AnalyzerImporterPlugin {
   private static final String PLUGIN_NAME = "GenericASTM";
 
   /**
-   * Thread-local storage for matched analyzer configuration.
+   * Thread-local storage for matched analyzer.
    *
    * <p>Since isTargetAnalyzer() and getAnalyzerLineInserter() are called separately by
-   * ASTMAnalyzerReader, we need to preserve the matched configuration between calls. Thread-local
+   * ASTMAnalyzerReader, we need to preserve the matched analyzer between calls. Thread-local
    * ensures thread safety for concurrent requests.
    */
-  private final ThreadLocal<AnalyzerConfiguration> matchedConfiguration = new ThreadLocal<>();
+  private final ThreadLocal<Analyzer> matchedAnalyzer = new ThreadLocal<>();
 
   /**
    * Register the generic plugin with PluginAnalyzerService.
@@ -71,7 +71,7 @@ public class GenericASTMAnalyzer implements AnalyzerImporterPlugin {
    * <ul>
    *   <li>Analyzers are created via 004 Dashboard, not plugin registration
    *   <li>Test mappings are configured via UI, not hardcoded
-   *   <li>This plugin serves MANY analyzers (one config per analyzer_configuration row)
+   *   <li>This plugin serves MANY analyzers (one per analyzer row with identifier_pattern)
    * </ul>
    *
    * @return true (always succeeds - actual analyzer lookup happens in isTargetAnalyzer)
@@ -98,8 +98,8 @@ public class GenericASTMAnalyzer implements AnalyzerImporterPlugin {
    *
    * <ol>
    *   <li>Parse ASTM H-segment for manufacturer/model identifier
-   *   <li>Query analyzer_configuration for generic plugin configs with matching identifier_pattern
-   *   <li>If match found, store configuration and return true
+   *   <li>Query analyzer table for rows with matching identifier_pattern
+   *   <li>If match found, store analyzer and return true
    * </ol>
    *
    * <p>Note: This is called AFTER legacy plugins have had a chance to match. Legacy plugins always
@@ -111,7 +111,7 @@ public class GenericASTMAnalyzer implements AnalyzerImporterPlugin {
   @Override
   public boolean isTargetAnalyzer(List<String> lines) {
     // Clear any previous match from thread-local
-    matchedConfiguration.remove();
+    matchedAnalyzer.remove();
 
     if (lines == null || lines.isEmpty()) {
       return false;
@@ -127,35 +127,32 @@ public class GenericASTMAnalyzer implements AnalyzerImporterPlugin {
       return false;
     }
 
-    // Query database for matching generic plugin configuration
+    // Query database for matching analyzer with identifier_pattern
     try {
-      AnalyzerConfigurationService configService =
-          SpringContext.getBean(AnalyzerConfigurationService.class);
+      AnalyzerService analyzerService = SpringContext.getBean(AnalyzerService.class);
 
-      if (configService == null) {
+      if (analyzerService == null) {
         LogEvent.logWarn(
             this.getClass().getSimpleName(),
             "isTargetAnalyzer",
-            "AnalyzerConfigurationService not available");
+            "AnalyzerService not available");
         return false;
       }
 
-      Optional<AnalyzerConfiguration> config =
-          configService.findByIdentifierPatternMatch(analyzerIdentifier);
+      Optional<Analyzer> analyzer =
+          analyzerService.findByIdentifierPatternMatch(analyzerIdentifier);
 
-      if (config.isPresent()) {
-        // Store matched configuration for getAnalyzerLineInserter()
-        matchedConfiguration.set(config.get());
+      if (analyzer.isPresent()) {
+        // Store matched analyzer for getAnalyzerLineInserter()
+        matchedAnalyzer.set(analyzer.get());
 
         LogEvent.logDebug(
             this.getClass().getSimpleName(),
             "isTargetAnalyzer",
             "Matched analyzer identifier '"
                 + analyzerIdentifier
-                + "' to configuration: "
-                + (config.get().getAnalyzer() != null
-                    ? config.get().getAnalyzer().getName()
-                    : config.get().getId()));
+                + "' to analyzer: "
+                + analyzer.get().getName());
         return true;
       }
 
@@ -191,18 +188,18 @@ public class GenericASTMAnalyzer implements AnalyzerImporterPlugin {
    */
   @Override
   public AnalyzerLineInserter getAnalyzerLineInserter() {
-    AnalyzerConfiguration config = matchedConfiguration.get();
+    Analyzer analyzer = matchedAnalyzer.get();
 
-    if (config == null || config.getAnalyzer() == null) {
+    if (analyzer == null) {
       LogEvent.logError(
           this.getClass().getSimpleName(),
           "getAnalyzerLineInserter",
-          "No matched configuration - isTargetAnalyzer() must be called first");
-      throw new IllegalStateException("No matched analyzer configuration");
+          "No matched analyzer - isTargetAnalyzer() must be called first");
+      throw new IllegalStateException("No matched analyzer");
     }
 
-    String analyzerId = config.getAnalyzer().getId();
-    String analyzerName = config.getAnalyzer().getName();
+    String analyzerId = analyzer.getId();
+    String analyzerName = analyzer.getName();
 
     LogEvent.logDebug(
         this.getClass().getSimpleName(),
@@ -218,7 +215,7 @@ public class GenericASTMAnalyzer implements AnalyzerImporterPlugin {
    * <p>ASTM H-segment format: H|\^&|||MANUFACTURER^MODEL^VERSION|...
    *
    * <p>Returns the full field 4 content (e.g., "HORIBA^YUMIZEN H500^1.0") to allow flexible pattern
-   * matching in analyzer_configuration.identifier_pattern.
+   * matching in analyzer.identifier_pattern.
    *
    * @param lines ASTM message lines
    * @return Analyzer identifier string, or null if not found

--- a/analyzers/GenericHL7/src/main/java/org/openelisglobal/plugins/analyzer/generichl7/GenericHL7Analyzer.java
+++ b/analyzers/GenericHL7/src/main/java/org/openelisglobal/plugins/analyzer/generichl7/GenericHL7Analyzer.java
@@ -16,8 +16,8 @@ package org.openelisglobal.plugins.analyzer.generichl7;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
-import org.openelisglobal.analyzer.service.AnalyzerConfigurationService;
-import org.openelisglobal.analyzer.valueholder.AnalyzerConfiguration;
+import org.openelisglobal.analyzer.service.AnalyzerService;
+import org.openelisglobal.analyzer.valueholder.Analyzer;
 import org.openelisglobal.analyzerimport.analyzerreaders.AnalyzerLineInserter;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.services.PluginAnalyzerService;
@@ -30,13 +30,13 @@ import org.openelisglobal.spring.util.SpringContext;
  * <p>Feature: 011-madagascar-analyzer-integration (M19)
  *
  * <p>Database-driven HL7 v2.x plugin that uses MSH-3 (sending application) pattern matching to
- * identify analyzers configured via analyzer_configuration.identifier_pattern.
+ * identify analyzers configured via analyzer.identifier_pattern (2-table model).
  *
  * <p>Unlike legacy HL7 plugins that hardcode analyzer identification, this generic plugin:
  *
  * <ul>
  *   <li>Extracts MSH-3 from HL7 messages
- *   <li>Matches against analyzer_configuration.identifier_pattern (regex)
+ *   <li>Matches against analyzer.identifier_pattern (regex)
  *   <li>Loads test mappings from analyzer_test_mapping table
  * </ul>
  *
@@ -60,13 +60,13 @@ public class GenericHL7Analyzer implements AnalyzerImporterPlugin {
   private static final String PLUGIN_NAME = "GenericHL7";
 
   /**
-   * Thread-local storage for matched analyzer configuration.
+   * Thread-local storage for matched analyzer.
    *
    * <p>Since isTargetAnalyzer() and getAnalyzerLineInserter() are called separately by
-   * HL7AnalyzerReader, we need to preserve the matched configuration between calls. Thread-local
-   * ensures thread safety for concurrent requests.
+   * HL7AnalyzerReader, we need to preserve the matched analyzer between calls. Thread-local ensures
+   * thread safety for concurrent requests.
    */
-  private final ThreadLocal<AnalyzerConfiguration> matchedConfiguration = new ThreadLocal<>();
+  private final ThreadLocal<Analyzer> matchedAnalyzer = new ThreadLocal<>();
 
   /**
    * Register the generic HL7 plugin with PluginAnalyzerService.
@@ -76,7 +76,7 @@ public class GenericHL7Analyzer implements AnalyzerImporterPlugin {
    * <ul>
    *   <li>Analyzers are created via Dashboard UI, not plugin registration
    *   <li>Test mappings are configured via UI, not hardcoded
-   *   <li>This plugin serves MANY analyzers (one config per analyzer_configuration row)
+   *   <li>This plugin serves MANY analyzers (one per analyzer row with identifier_pattern)
    * </ul>
    *
    * @return true (always succeeds - actual analyzer lookup happens in isTargetAnalyzer)
@@ -103,8 +103,8 @@ public class GenericHL7Analyzer implements AnalyzerImporterPlugin {
    *
    * <ol>
    *   <li>Parse HL7 MSH segment for MSH-3 (sending application)
-   *   <li>Query analyzer_configuration for generic plugin configs with matching identifier_pattern
-   *   <li>If match found, store configuration and return true
+   *   <li>Query analyzer table for rows with matching identifier_pattern
+   *   <li>If match found, store analyzer and return true
    * </ol>
    *
    * <p>Note: All plugins (legacy and generic) are in one list; the first plugin for which
@@ -116,7 +116,7 @@ public class GenericHL7Analyzer implements AnalyzerImporterPlugin {
   @Override
   public boolean isTargetAnalyzer(List<String> lines) {
     // Clear any previous match from thread-local
-    matchedConfiguration.remove();
+    matchedAnalyzer.remove();
 
     if (lines == null || lines.isEmpty()) {
       return false;
@@ -132,33 +132,27 @@ public class GenericHL7Analyzer implements AnalyzerImporterPlugin {
       return false;
     }
 
-    // Query database for matching generic plugin configuration
+    // Query database for matching analyzer with identifier_pattern
     try {
-      AnalyzerConfigurationService configService =
-          SpringContext.getBean(AnalyzerConfigurationService.class);
+      AnalyzerService analyzerService = SpringContext.getBean(AnalyzerService.class);
 
-      if (configService == null) {
+      if (analyzerService == null) {
         LogEvent.logWarn(
             this.getClass().getSimpleName(),
             "isTargetAnalyzer",
-            "AnalyzerConfigurationService not available");
+            "AnalyzerService not available");
         return false;
       }
 
-      Optional<AnalyzerConfiguration> config = configService.findByIdentifierPatternMatch(msh3);
-      if (config.isPresent()) {
-        // Store matched configuration for getAnalyzerLineInserter()
-        matchedConfiguration.set(config.get());
+      Optional<Analyzer> analyzer = analyzerService.findByIdentifierPatternMatch(msh3);
+      if (analyzer.isPresent()) {
+        // Store matched analyzer for getAnalyzerLineInserter()
+        matchedAnalyzer.set(analyzer.get());
 
         LogEvent.logDebug(
             this.getClass().getSimpleName(),
             "isTargetAnalyzer",
-            "Matched MSH-3 '"
-                + msh3
-                + "' to configuration: "
-                + (config.get().getAnalyzer() != null
-                    ? config.get().getAnalyzer().getName()
-                    : config.get().getId()));
+            "Matched MSH-3 '" + msh3 + "' to analyzer: " + analyzer.get().getName());
         return true;
       }
 
@@ -193,18 +187,18 @@ public class GenericHL7Analyzer implements AnalyzerImporterPlugin {
    */
   @Override
   public AnalyzerLineInserter getAnalyzerLineInserter() {
-    AnalyzerConfiguration config = matchedConfiguration.get();
+    Analyzer analyzer = matchedAnalyzer.get();
 
-    if (config == null || config.getAnalyzer() == null) {
+    if (analyzer == null) {
       LogEvent.logError(
           this.getClass().getSimpleName(),
           "getAnalyzerLineInserter",
-          "No matched configuration - isTargetAnalyzer() must be called first");
-      throw new IllegalStateException("No matched analyzer configuration");
+          "No matched analyzer - isTargetAnalyzer() must be called first");
+      throw new IllegalStateException("No matched analyzer");
     }
 
-    String analyzerId = config.getAnalyzer().getId();
-    String analyzerName = config.getAnalyzer().getName();
+    String analyzerId = analyzer.getId();
+    String analyzerName = analyzer.getName();
 
     LogEvent.logDebug(
         this.getClass().getSimpleName(),
@@ -221,7 +215,7 @@ public class GenericHL7Analyzer implements AnalyzerImporterPlugin {
    * Segment ID ("MSH") - Field 1: Field separator ("|") - Field 2: Encoding characters ("^~\&") -
    * Field 3: Sending Application (MSH-3) ← We extract this - Field 4: Sending Facility (MSH-4)
    *
-   * <p>Returns MSH-3 value to match against analyzer_configuration.identifier_pattern.
+   * <p>Returns MSH-3 value to match against analyzer.identifier_pattern.
    *
    * @param lines HL7 message segment lines
    * @return MSH-3 sending application string, or null if not found

--- a/analyzers/GenericHL7/src/test/java/org/openelisglobal/plugins/analyzer/generichl7/GenericHL7AnalyzerTest.java
+++ b/analyzers/GenericHL7/src/test/java/org/openelisglobal/plugins/analyzer/generichl7/GenericHL7AnalyzerTest.java
@@ -12,9 +12,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.openelisglobal.analyzer.service.AnalyzerConfigurationService;
+import org.openelisglobal.analyzer.service.AnalyzerService;
 import org.openelisglobal.analyzer.valueholder.Analyzer;
-import org.openelisglobal.analyzer.valueholder.AnalyzerConfiguration;
 
 /**
  * Unit tests for GenericHL7Analyzer plugin.
@@ -27,7 +26,7 @@ import org.openelisglobal.analyzer.valueholder.AnalyzerConfiguration;
 @RunWith(MockitoJUnitRunner.class)
 public class GenericHL7AnalyzerTest {
 
-  @Mock private AnalyzerConfigurationService mockConfigService;
+  @Mock private AnalyzerService mockAnalyzerService;
 
   private GenericHL7Analyzer analyzer;
 
@@ -82,18 +81,15 @@ public class GenericHL7AnalyzerTest {
     // Arrange: HL7 message with MSH-3 = "MINDRAY"
     List<String> lines = Arrays.asList("MSH|^~\\&||MINDRAY||||ORU^R01|MSG001|P|2.3.1");
 
-    // Mock configuration service to return matching config
-    AnalyzerConfiguration mockConfig = new AnalyzerConfiguration();
+    // Mock analyzer with matching identifier pattern (2-table model)
     Analyzer mockAnalyzer = new Analyzer();
     mockAnalyzer.setId("ANALYZER-001");
     mockAnalyzer.setName("Mindray BC2000");
-    mockConfig.setAnalyzer(mockAnalyzer);
-    mockConfig.setIdentifierPattern("MINDRAY.*BC.?2000");
-    mockConfig.setGenericPlugin(true);
+    mockAnalyzer.setIdentifierPattern("MINDRAY.*BC.?2000");
 
     // This test will fail until we implement isTargetAnalyzer() properly
     // Expected: analyzer should extract "MINDRAY" from MSH-3 and call
-    // configService.findByIdentifierPatternMatch("MINDRAY")
+    // analyzerService.findByIdentifierPatternMatch("MINDRAY")
 
     // Act
     boolean result = analyzer.isTargetAnalyzer(lines);


### PR DESCRIPTION
## Summary
- Adapt `GenericASTMAnalyzer` and `GenericHL7Analyzer` to the 2-table model (`analyzer` + `analyzer_type`)
- Replace `AnalyzerConfigurationService` / `AnalyzerConfiguration` references with `AnalyzerService` / `Analyzer`
- `identifier_pattern` is now read directly from the `analyzer` entity instead of `analyzer_configuration`

## Context
Companion PR to [OpenELIS-Global-2 #2802](https://github.com/DIGI-UW/OpenELIS-Global-2/pull/2802), which merges the `analyzer_configuration` table into `analyzer`.

## Test plan
- [x] `GenericHL7AnalyzerTest` — updated mocks and imports
- [x] Plugin compilation against updated main project classes JAR

🤖 Generated with [Claude Code](https://claude.com/claude-code)