### PR TITLE
feat(011): GenericASTM QC detection, value cleanup, and integration test fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,10 @@ on:
     branches: [develop]
   workflow_dispatch:
 
-# TEMPORARY: GenericASTM/GenericHL7 plugins require AnalyzerService.findByIdentifierPatternMatch()
-# and the merged 2-table model (analyzer_configuration merged into analyzer), which exists on
-# fix/011-sync-remediation but not yet on feat/011 or develop.
-#
-# EXIT CRITERIA: Revert to OE 'feat/011-madagascar-analyzer-integration' once PR #2802
-# (fix/011-sync-remediation) is merged, then revert to 'develop' once feat/011 merges.
-#
-# Tracking: specs/011-madagascar-analyzer-integration (OE repo)
+# The 2-table model and GenericASTM/GenericHL7 plugin support are on develop
+# since feat/011 merged (PR #2767).
 env:
-  OE_REF: fix/011-sync-remediation
+  OE_REF: develop
 
 jobs:
   build:

--- a/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMAnalyzer.java
+++ b/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMAnalyzer.java
@@ -133,9 +133,7 @@ public class GenericASTMAnalyzer implements AnalyzerImporterPlugin {
 
       if (analyzerService == null) {
         LogEvent.logWarn(
-            this.getClass().getSimpleName(),
-            "isTargetAnalyzer",
-            "AnalyzerService not available");
+            this.getClass().getSimpleName(), "isTargetAnalyzer", "AnalyzerService not available");
         return false;
       }
 

--- a/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMLineInserter.java
+++ b/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMLineInserter.java
@@ -71,6 +71,7 @@ public class GenericASTMLineInserter extends AnalyzerLineInserter {
 
   // O-segment field indices
   private static final int O_SPECIMEN_ID_FIELD = 2;
+  private static final int O_ACTION_CODE_FIELD = 11; // O.12 (1-based) = index 11 (0-based)
 
   // Common ASTM timestamp formats
   private static final String ASTM_TIMESTAMP_PATTERN = "yyyyMMddHHmmss";
@@ -208,7 +209,8 @@ public class GenericASTMLineInserter extends AnalyzerLineInserter {
       return;
     }
 
-    String resultValue = resultFields.length > R_VALUE_FIELD ? resultFields[R_VALUE_FIELD] : "";
+    String resultValue =
+        cleanResultValue(resultFields.length > R_VALUE_FIELD ? resultFields[R_VALUE_FIELD] : "");
     String units = resultFields.length > R_UNITS_FIELD ? resultFields[R_UNITS_FIELD] : "";
     String timestampStr =
         resultFields.length > R_TIMESTAMP_FIELD ? resultFields[R_TIMESTAMP_FIELD] : "";
@@ -234,7 +236,7 @@ public class GenericASTMLineInserter extends AnalyzerLineInserter {
     analyzerResult.setResult(resultValue);
     analyzerResult.setUnits(units);
     analyzerResult.setAccessionNumber(accessionNumber);
-    analyzerResult.setIsControl(false);
+    analyzerResult.setIsControl(isQcSample(orderRecord));
 
     // Parse completion timestamp
     Timestamp completeDate = parseTimestamp(timestampStr);
@@ -259,6 +261,51 @@ public class GenericASTMLineInserter extends AnalyzerLineInserter {
             + units
             + " for accession "
             + accessionNumber);
+  }
+
+  /**
+   * Check if the O-record indicates a QC sample via Action Code (O.12).
+   *
+   * <p>Per ASTM E-1394-97 and Cepheid GeneXpert LIS spec, O.12 = "Q" indicates a QC sample. This
+   * determines whether the result is routed to the QC queue or the patient results queue.
+   *
+   * @param orderRecord the O-segment line
+   * @return true if Action Code is "Q" (QC sample)
+   */
+  private boolean isQcSample(String orderRecord) {
+    String[] fields = orderRecord.split(Pattern.quote(FIELD_DELIMITER));
+    if (fields.length > O_ACTION_CODE_FIELD) {
+      return "Q".equalsIgnoreCase(fields[O_ACTION_CODE_FIELD].trim());
+    }
+    return false;
+  }
+
+  /**
+   * Clean ASTM result value by stripping component delimiters.
+   *
+   * <p>Some analyzers (notably GeneXpert per Cepheid LIS spec) use multi-component R.4 values:
+   *
+   * <ul>
+   *   <li>Qualitative: {@code NEGATIVE^} (value in component 1, empty component 2)
+   *   <li>Quantitative complementary: {@code ^3.10} (empty component 1, value in component 2)
+   * </ul>
+   *
+   * <p>This method strips leading/trailing component delimiters to extract the clean value.
+   *
+   * @param value raw R.4 field value
+   * @return cleaned value with component delimiters removed
+   */
+  private String cleanResultValue(String value) {
+    if (value == null || value.isEmpty()) {
+      return value;
+    }
+    // Strip trailing component delimiters (e.g., "NEGATIVE^" → "NEGATIVE")
+    String cleaned = value.replaceAll("\\^+$", "");
+    // Strip leading component delimiter (e.g., "^3.10" → "3.10")
+    if (cleaned.startsWith(COMPONENT_DELIMITER)) {
+      cleaned = cleaned.substring(1);
+    }
+    return cleaned;
   }
 
   /**

--- a/analyzers/GenericASTM/src/test/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMIntegrationTest.java
+++ b/analyzers/GenericASTM/src/test/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMIntegrationTest.java
@@ -360,7 +360,8 @@ public class GenericASTMIntegrationTest extends BaseWebContextSensitiveTest {
             + " OR analyzer_id = '2006'");
     jdbcTemplate.execute("DELETE FROM analyzer_test_map WHERE analyzer_id = '2006'");
     jdbcTemplate.execute("DELETE FROM analyzer WHERE id = '2006'");
-    jdbcTemplate.execute("DELETE FROM analyzer_type WHERE id = 9999");
+    // Do NOT delete analyzer_type — it may be shared or pre-seeded by Liquibase.
+    // The ON CONFLICT DO NOTHING in loadFixtures() is safe for re-runs.
   }
 
   /**
@@ -373,19 +374,28 @@ public class GenericASTMIntegrationTest extends BaseWebContextSensitiveTest {
   private void loadFixtures() {
     jdbcTemplate.execute("SET search_path TO clinlims");
 
-    // Create analyzer_type for GenericASTM (mirrors what PluginRegistryService does at startup)
+    // Ensure an analyzer_type row exists for GenericASTM with is_generic_plugin=true.
+    // Use ON CONFLICT DO NOTHING to avoid rewriting the PK of an existing row (which would
+    // break FK relationships for other analyzers sharing this type).
     jdbcTemplate.execute(
         "INSERT INTO analyzer_type (id, name, description, protocol, plugin_class_name, is_generic_plugin, is_active, last_updated) "
-            + "VALUES (9999, 'GenericASTM', 'Generic ASTM analyzer plugin', 'ASTM', "
+            + "VALUES (nextval('analyzer_type_seq'), 'GenericASTM', 'Generic ASTM analyzer plugin', 'ASTM', "
             + "'org.openelisglobal.plugins.analyzer.genericastm.GenericASTMAnalyzer', true, true, NOW()) "
-            + "ON CONFLICT (name) DO UPDATE SET id = EXCLUDED.id");
+            + "ON CONFLICT (name) DO NOTHING");
+
+    // Resolve the actual ID (may differ from what we tried to insert if the row already existed)
+    Long analyzerTypeId =
+        jdbcTemplate.queryForObject(
+            "SELECT id FROM analyzer_type WHERE name = 'GenericASTM'", Long.class);
 
     // Insert analyzer WITH analyzer_type_id — required for findGenericAnalyzersWithPatterns() INNER
     // JOIN
     jdbcTemplate.execute(
         "INSERT INTO analyzer (id, name, analyzer_type, description, identifier_pattern, is_active, analyzer_type_id, last_updated) "
             + "VALUES ('2006', 'Mindray BA-88A', 'CHEMISTRY', 'ASTM over RS232 Serial', "
-            + "'MINDRAY.*BA-88A|BA88A', true, 9999, NOW())");
+            + "'MINDRAY.*BA-88A|BA88A', true, "
+            + analyzerTypeId
+            + ", NOW())");
 
     String[][] testMappings = {{"GLUCOSE", "1"}, {"HGB", "2"}};
 

--- a/analyzers/GenericASTM/src/test/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMIntegrationTest.java
+++ b/analyzers/GenericASTM/src/test/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMIntegrationTest.java
@@ -199,30 +199,193 @@ public class GenericASTMIntegrationTest extends BaseWebContextSensitiveTest {
         countForAnalyzer != null && countForAnalyzer >= 2);
   }
 
-  private void cleanTestData() {
-    jdbcTemplate.execute(
-        "DELETE FROM analyzer_results WHERE accession_number LIKE '2026-A%' OR analyzer_id = '2006'");
-    jdbcTemplate.execute("DELETE FROM analyzer_test_map WHERE analyzer_id = '2006'");
-    jdbcTemplate.execute("DELETE FROM analyzer_configuration WHERE analyzer_id = '2006'");
-    jdbcTemplate.execute("DELETE FROM analyzer WHERE id = '2006'");
+  /**
+   * Test that QC samples (O.12 = "Q") are marked as control results.
+   *
+   * <p>Per ASTM E-1394-97 and Cepheid GeneXpert LIS spec, O.12 (Action Code) = "Q" indicates a QC
+   * sample. The GenericASTMLineInserter should set isControl=true for these results.
+   */
+  @Test
+  public void testGenericASTM_QcActionCode_MarksResultAsControl() throws Exception {
+    // 26-field O-record with O.12 (index 11) = "Q" for QC sample
+    String astmMessage =
+        "H|\\^&|||MINDRAY^BA-88A^1.0|INST||20260202|||ASTM^LIS2-A2^LIS2-A2\r\n"
+            + "P|1||PAT003|||M|19800101||\r\n"
+            + "O|1|QC-CTRL-001|||||||||Q|||||||||||||\r\n"
+            + "R|1|^^^GLUCOSE|100.0|mg/dL|||||20260202120000|N\r\n"
+            + "L|1|N\r\n";
+
+    InputStream stream = new ByteArrayInputStream(astmMessage.getBytes(StandardCharsets.UTF_8));
+
+    ASTMAnalyzerReader reader = new ASTMAnalyzerReader();
+    boolean streamRead = reader.readStream(stream);
+    boolean inserted = reader.insertAnalyzerData("systemUser");
+
+    assertTrue("ASTM stream should be read successfully", streamRead);
+    assertTrue("Results should be inserted successfully", inserted);
+
+    Boolean isControl =
+        jdbcTemplate.queryForObject(
+            "SELECT iscontrol FROM clinlims.analyzer_results WHERE accession_number = 'QC-CTRL-001' LIMIT 1",
+            Boolean.class);
+    assertNotNull("QC result should be persisted", isControl);
+    assertTrue("QC result should be marked as control (O.12 = 'Q')", isControl);
   }
 
   /**
-   * Load analyzer 2006 (Mindray BA-88A), its generic-plugin configuration, and test mappings. Uses
-   * test ids 1 and 2 from test-result.xml (with localization). No madagascar-analyzer-test-data.xml
-   * to avoid DBUnit column mismatch (fhir_uuid).
+   * Test that patient samples (O.12 empty) are NOT marked as control results.
+   *
+   * <p>Normal patient samples have an empty or absent Action Code field. The
+   * GenericASTMLineInserter should set isControl=false for these results.
+   */
+  @Test
+  public void testGenericASTM_PatientSample_NotMarkedAsControl() throws Exception {
+    String astmMessage =
+        "H|\\^&|||MINDRAY^BA-88A^1.0|INST||20260202|||ASTM^LIS2-A2^LIS2-A2\r\n"
+            + "P|1||PAT004|||F|19900101||\r\n"
+            + "O|1|2026-A04|||20260202120000||||\r\n"
+            + "R|1|^^^GLUCOSE|95.0|mg/dL|20260202120000|N\r\n"
+            + "L|1|N\r\n";
+
+    InputStream stream = new ByteArrayInputStream(astmMessage.getBytes(StandardCharsets.UTF_8));
+
+    ASTMAnalyzerReader reader = new ASTMAnalyzerReader();
+    reader.readStream(stream);
+    reader.insertAnalyzerData("systemUser");
+
+    Boolean isControl =
+        jdbcTemplate.queryForObject(
+            "SELECT iscontrol FROM clinlims.analyzer_results WHERE accession_number = '2026-A04' LIMIT 1",
+            Boolean.class);
+    assertNotNull("Patient result should be persisted", isControl);
+    assertFalse("Patient result should NOT be marked as control", isControl);
+  }
+
+  /**
+   * Test that trailing component delimiters are stripped from qualitative R.4 values.
+   *
+   * <p>Per Cepheid GeneXpert LIS spec, qualitative results use R.4 format: "NEGATIVE^" (value in
+   * component 1, empty component 2). The GenericASTMLineInserter should strip the trailing ^ to
+   * store "NEGATIVE".
+   */
+  @Test
+  public void testGenericASTM_TrailingCaret_StrippedFromQualitativeValue() throws Exception {
+    String astmMessage =
+        "H|\\^&|||MINDRAY^BA-88A^1.0|INST||20260202|||ASTM^LIS2-A2^LIS2-A2\r\n"
+            + "P|1||PAT005|||M|19800101||\r\n"
+            + "O|1|2026-A05|||20260202120000||||\r\n"
+            + "R|1|^^^GLUCOSE|NEGATIVE^||||||20260202120000|N\r\n"
+            + "L|1|N\r\n";
+
+    InputStream stream = new ByteArrayInputStream(astmMessage.getBytes(StandardCharsets.UTF_8));
+
+    ASTMAnalyzerReader reader = new ASTMAnalyzerReader();
+    reader.readStream(stream);
+    reader.insertAnalyzerData("systemUser");
+
+    String storedValue =
+        jdbcTemplate.queryForObject(
+            "SELECT result FROM clinlims.analyzer_results WHERE accession_number = '2026-A05' LIMIT 1",
+            String.class);
+    assertNotNull("Result should be persisted", storedValue);
+    assertFalse(
+        "Stored value should not contain trailing ^: " + storedValue, storedValue.endsWith("^"));
+    assertTrue("Stored value should be 'NEGATIVE': " + storedValue, "NEGATIVE".equals(storedValue));
+  }
+
+  /**
+   * Test that leading component delimiters are stripped from complementary R.4 values.
+   *
+   * <p>Per Cepheid GeneXpert LIS spec, complementary quantitative results use R.4 format: "^3.10"
+   * (empty component 1, value in component 2). The GenericASTMLineInserter should strip the leading
+   * ^ to store "3.10".
+   */
+  @Test
+  public void testGenericASTM_LeadingCaret_StrippedFromComplementaryValue() throws Exception {
+    String astmMessage =
+        "H|\\^&|||MINDRAY^BA-88A^1.0|INST||20260202|||ASTM^LIS2-A2^LIS2-A2\r\n"
+            + "P|1||PAT006|||M|19800101||\r\n"
+            + "O|1|2026-A06|||20260202120000||||\r\n"
+            + "R|1|^^^GLUCOSE|^3.10||||||20260202120000|N\r\n"
+            + "L|1|N\r\n";
+
+    InputStream stream = new ByteArrayInputStream(astmMessage.getBytes(StandardCharsets.UTF_8));
+
+    ASTMAnalyzerReader reader = new ASTMAnalyzerReader();
+    reader.readStream(stream);
+    reader.insertAnalyzerData("systemUser");
+
+    String storedValue =
+        jdbcTemplate.queryForObject(
+            "SELECT result FROM clinlims.analyzer_results WHERE accession_number = '2026-A06' LIMIT 1",
+            String.class);
+    assertNotNull("Result should be persisted", storedValue);
+    assertFalse(
+        "Stored value should not contain leading ^: " + storedValue, storedValue.startsWith("^"));
+    assertTrue("Stored value should be '3.10': " + storedValue, "3.10".equals(storedValue));
+  }
+
+  /**
+   * Test that normal numeric values pass through unchanged (no false stripping).
+   *
+   * <p>Values like "105.5" should be stored exactly as-is.
+   */
+  @Test
+  public void testGenericASTM_NormalNumericValue_PassesThroughUnchanged() throws Exception {
+    String astmMessage =
+        "H|\\^&|||MINDRAY^BA-88A^1.0|INST||20260202|||ASTM^LIS2-A2^LIS2-A2\r\n"
+            + "P|1||PAT007|||F|19900101||\r\n"
+            + "O|1|2026-A07|||20260202120000||||\r\n"
+            + "R|1|^^^GLUCOSE|105.5|mg/dL|20260202120000|N\r\n"
+            + "L|1|N\r\n";
+
+    InputStream stream = new ByteArrayInputStream(astmMessage.getBytes(StandardCharsets.UTF_8));
+
+    ASTMAnalyzerReader reader = new ASTMAnalyzerReader();
+    reader.readStream(stream);
+    reader.insertAnalyzerData("systemUser");
+
+    String storedValue =
+        jdbcTemplate.queryForObject(
+            "SELECT result FROM clinlims.analyzer_results WHERE accession_number = '2026-A07' LIMIT 1",
+            String.class);
+    assertNotNull("Result should be persisted", storedValue);
+    assertTrue("Normal value should be unchanged: " + storedValue, "105.5".equals(storedValue));
+  }
+
+  private void cleanTestData() {
+    jdbcTemplate.execute(
+        "DELETE FROM analyzer_results WHERE accession_number LIKE '2026-A%'"
+            + " OR accession_number LIKE 'QC-CTRL%'"
+            + " OR analyzer_id = '2006'");
+    jdbcTemplate.execute("DELETE FROM analyzer_test_map WHERE analyzer_id = '2006'");
+    jdbcTemplate.execute("DELETE FROM analyzer WHERE id = '2006'");
+    jdbcTemplate.execute("DELETE FROM analyzer_type WHERE id = 9999");
+  }
+
+  /**
+   * Load analyzer 2006 (Mindray BA-88A) and test mappings. Uses test ids 1 and 2 from
+   * test-result.xml (with localization).
+   *
+   * <p>NOTE: identifier_pattern is set on the analyzer row — this is where the runtime DAO
+   * (AnalyzerDAOImpl.findGenericAnalyzersWithPatterns) reads it from.
    */
   private void loadFixtures() {
     jdbcTemplate.execute("SET search_path TO clinlims");
 
+    // Create analyzer_type for GenericASTM (mirrors what PluginRegistryService does at startup)
     jdbcTemplate.execute(
-        "INSERT INTO analyzer (id, name, analyzer_type, description, is_active, last_updated) "
-            + "VALUES ('2006', 'Mindray BA-88A', 'CHEMISTRY', 'ASTM over RS232 Serial', true, NOW())");
+        "INSERT INTO analyzer_type (id, name, description, protocol, plugin_class_name, is_generic_plugin, is_active, last_updated) "
+            + "VALUES (9999, 'GenericASTM', 'Generic ASTM analyzer plugin', 'ASTM', "
+            + "'org.openelisglobal.plugins.analyzer.genericastm.GenericASTMAnalyzer', true, true, NOW()) "
+            + "ON CONFLICT (name) DO UPDATE SET id = EXCLUDED.id");
 
+    // Insert analyzer WITH analyzer_type_id — required for findGenericAnalyzersWithPatterns() INNER
+    // JOIN
     jdbcTemplate.execute(
-        "INSERT INTO analyzer_configuration "
-            + "(id, analyzer_id, protocol_version, identifier_pattern, is_generic_plugin, status, sys_user_id, last_updated) "
-            + "VALUES ('CONFIG-2006', '2006', 'ASTM LIS2-A2', 'MINDRAY.*BA-88A|BA88A', true, 'ACTIVE', '1', NOW())");
+        "INSERT INTO analyzer (id, name, analyzer_type, description, identifier_pattern, is_active, analyzer_type_id, last_updated) "
+            + "VALUES ('2006', 'Mindray BA-88A', 'CHEMISTRY', 'ASTM over RS232 Serial', "
+            + "'MINDRAY.*BA-88A|BA88A', true, 9999, NOW())");
 
     String[][] testMappings = {{"GLUCOSE", "1"}, {"HGB", "2"}};
 

--- a/analyzers/GenericHL7/ARCHITECTURE.md
+++ b/analyzers/GenericHL7/ARCHITECTURE.md
@@ -500,7 +500,7 @@ OBX|3|NM|HGB^Hemoglobin||14.5|g/dL|12.0-16.0|N|||F
 
 - [GenericASTM Plugin](../GenericASTM/README.md) - Similar pattern for ASTM
 - [Feature 011 Spec](../../../specs/011-madagascar-analyzer-integration/spec.md)
-- [Default Config Templates](../../../projects/analyzer-defaults/README.md)
+- Default Config Templates (see the shared analyzer-defaults configuration repository or centralized documentation)
 - [HL7 v2.3.1 Specification](http://www.hl7.org/)
 
 ---

--- a/analyzers/GenericHL7/ARCHITECTURE.md
+++ b/analyzers/GenericHL7/ARCHITECTURE.md
@@ -500,7 +500,7 @@ OBX|3|NM|HGB^Hemoglobin||14.5|g/dL|12.0-16.0|N|||F
 
 - [GenericASTM Plugin](../GenericASTM/README.md) - Similar pattern for ASTM
 - [Feature 011 Spec](../../../specs/011-madagascar-analyzer-integration/spec.md)
-- Default Config Templates (see the shared analyzer-defaults configuration repository or centralized documentation)
+- [Default Config Templates](https://github.com/DIGI-UW/OpenELIS-Global-2/tree/develop/projects/analyzer-defaults)
 - [HL7 v2.3.1 Specification](http://www.hl7.org/)
 
 ---

--- a/analyzers/GenericHL7/ARCHITECTURE.md
+++ b/analyzers/GenericHL7/ARCHITECTURE.md
@@ -500,7 +500,7 @@ OBX|3|NM|HGB^Hemoglobin||14.5|g/dL|12.0-16.0|N|||F
 
 - [GenericASTM Plugin](../GenericASTM/README.md) - Similar pattern for ASTM
 - [Feature 011 Spec](../../../specs/011-madagascar-analyzer-integration/spec.md)
-- [Default Config Templates](../../../analyzer-defaults/README.md)
+- [Default Config Templates](../../../projects/analyzer-defaults/README.md)
 - [HL7 v2.3.1 Specification](http://www.hl7.org/)
 
 ---

--- a/analyzers/GenericHL7/README.md
+++ b/analyzers/GenericHL7/README.md
@@ -259,7 +259,7 @@ VALUES ('ANALYZER-ID', 'XYZ', (SELECT id FROM test WHERE name = 'XYZ Test'));
 - [GenericASTM Plugin](../GenericASTM/README.md) - ASTM equivalent
 - [Feature 011 Spec](../../../specs/011-madagascar-analyzer-integration/spec.md)
 - [GenericHL7 Architecture](../../../plugins/analyzers/GenericHL7/ARCHITECTURE.md)
-- [Analyzer Defaults](../../../analyzer-defaults/README.md)
+- [Analyzer Defaults](../../../projects/analyzer-defaults/README.md)
 
 ---
 

--- a/analyzers/GenericHL7/README.md
+++ b/analyzers/GenericHL7/README.md
@@ -259,7 +259,7 @@ VALUES ('ANALYZER-ID', 'XYZ', (SELECT id FROM test WHERE name = 'XYZ Test'));
 - [GenericASTM Plugin](../GenericASTM/README.md) - ASTM equivalent
 - [Feature 011 Spec](../../../specs/011-madagascar-analyzer-integration/spec.md)
 - [GenericHL7 Architecture](../../../plugins/analyzers/GenericHL7/ARCHITECTURE.md)
-- [Analyzer Defaults](../../../projects/analyzer-defaults/README.md)
+- [Analyzer Defaults](https://github.com/DIGI-UW/OpenELIS-Global-2/tree/develop/projects/analyzer-defaults)
 
 ---
 


### PR DESCRIPTION
## Summary
- Parse ASTM O.12 Action Code to detect QC samples (`isControl=true` when `"Q"`)
- Strip trailing/leading `^` from R.4 values (GeneXpert qualitative/complementary format per Cepheid LIS spec)
- Add 5 new integration tests covering QC detection, value cleanup, and normal passthrough
- Fix test fixtures: use `ON CONFLICT DO NOTHING` + `SELECT` for `analyzer_type` (avoids rewriting PK), link analyzer to `analyzer_type` with `is_generic_plugin=true`, use correct column name `iscontrol`
- Fix broken docs links in GenericHL7 README/ARCHITECTURE (link to parent repo)
- Update CI `OE_REF` from deleted `fix/011-sync-remediation` to `develop`

## Test plan
- [x] All 8 GenericASTM integration tests pass
- [x] CI green
- [ ] Verify QC samples routed to QC queue in E2E harness
- [ ] Verify qualitative values stored without trailing `^`

🤖 Generated with [Claude Code](https://claude.com/claude-code)