### PR TITLE
fix: add XML plugin descriptors for GenericASTM and GenericHL7

### DIFF
--- a/analyzers/GenericASTM/src/main/resources/GenericASTM.xml
+++ b/analyzers/GenericASTM/src/main/resources/GenericASTM.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openElisGlobalPlugin>
+    <version>1.0</version>
+    <analyzerImporter>
+        <extension_point path="org.openelisglobal.plugin.AnalyzerImporterPlugin">
+            <extension path="org.openelisglobal.plugins.analyzer.genericastm.GenericASTMAnalyzer" />
+            <description value="GenericASTM" />
+        </extension_point>
+    </analyzerImporter>
+</openElisGlobalPlugin>

--- a/analyzers/GenericHL7/src/main/resources/GenericHL7.xml
+++ b/analyzers/GenericHL7/src/main/resources/GenericHL7.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openElisGlobalPlugin>
+    <version>1.0</version>
+    <analyzerImporter>
+        <extension_point path="org.openelisglobal.plugin.AnalyzerImporterPlugin">
+            <extension path="org.openelisglobal.plugins.analyzer.generichl7.GenericHL7Analyzer" />
+            <description value="GenericHL7" />
+        </extension_point>
+    </analyzerImporter>
+</openElisGlobalPlugin>


### PR DESCRIPTION
## Summary
- Added `GenericASTM.xml` and `GenericHL7.xml` plugin descriptors to `src/main/resources/` for both generic analyzer plugins
- `PluginLoader` requires an XML descriptor inside each JAR to discover the plugin class and call `connect()`. Without these, the plugins were never instantiated despite the JARs being present in `/var/lib/openelis-global/plugins/`

## Paired with
- DIGI-UW/OpenELIS-Global-2#2950 (updates submodule pointer to this commit)

## Test plan
- [ ] Rebuild plugin JARs (`cd plugins && mvn package`)
- [ ] Verify XML is inside JAR: `unzip -l plugins/GenericASTM-1.0.jar | grep xml`
- [ ] Deploy to harness, check logs for "GenericASTM plugin registered" and "Loaded: GenericASTM"
- [ ] Verify `pluginLoaded=true` on analyzer dashboard for all generic-plugin analyzers

🤖 Generated with [Claude Code](https://claude.com/claude-code)