### PR TITLE
feat: GenericASTM responder for ASTM Q-record bidirectional flow

### DIFF
--- a/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMAnalyzer.java
+++ b/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMAnalyzer.java
@@ -194,7 +194,8 @@ public class GenericASTMAnalyzer implements AnalyzerImporterPlugin {
           this.getClass().getSimpleName(),
           "getAnalyzerLineInserter",
           "No matched analyzer - isTargetAnalyzer() must be called first");
-      throw new IllegalStateException("No matched analyzer");
+      throw new IllegalStateException(
+          "No matched analyzer - isTargetAnalyzer() must be called first");
     }
 
     String analyzerId = analyzer.getAnalyzerType().getId();
@@ -241,7 +242,8 @@ public class GenericASTMAnalyzer implements AnalyzerImporterPlugin {
           this.getClass().getSimpleName(),
           "getAnalyzerResponder",
           "No matched analyzer - isTargetAnalyzer() must be called first");
-      throw new IllegalStateException("No matched analyzer");
+      throw new IllegalStateException(
+          "No matched analyzer - isTargetAnalyzer() must be called first");
     }
 
     String analyzerTypeId = analyzer.getAnalyzerType().getId();

--- a/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMAnalyzer.java
+++ b/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMAnalyzer.java
@@ -236,8 +236,17 @@ public class GenericASTMAnalyzer implements AnalyzerImporterPlugin {
   @Override
   public AnalyzerResponder getAnalyzerResponder() {
     Analyzer analyzer = matchedAnalyzer.get();
-    String analyzerId = analyzer.getId();
-    String analyzerName = analyzer.getName();
-     return new GenericASTMLineInserter(analyzerId, analyzerName);
+    if (analyzer == null) {
+      LogEvent.logError(
+          this.getClass().getSimpleName(),
+          "getAnalyzerResponder",
+          "No matched analyzer - isTargetAnalyzer() must be called first");
+      throw new IllegalStateException("No matched analyzer");
+    }
+
+    String analyzerTypeId = analyzer.getAnalyzerType().getId();
+    String analyzerTypeName = analyzer.getAnalyzerType().getName();
+
+    return new GenericASTMResponder(analyzerTypeId, analyzerTypeName);
   }
 }

--- a/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMLineInserter.java
+++ b/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMLineInserter.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.regex.Pattern;
 import org.openelisglobal.analyzerimport.analyzerreaders.AnalyzerLineInserter;
 import org.openelisglobal.analyzerimport.analyzerreaders.AnalyzerReaderUtil;
-import org.openelisglobal.analyzerimport.analyzerreaders.AnalyzerResponder;
 import org.openelisglobal.analyzerimport.util.AnalyzerTestNameCache;
 import org.openelisglobal.analyzerimport.util.MappedTestName;
 import org.openelisglobal.analyzerresults.valueholder.AnalyzerResults;
@@ -50,7 +49,7 @@ import org.openelisglobal.common.util.DateUtil;
  *   <li>L-segment: terminates the message
  * </ul>
  */
-public class GenericASTMLineInserter extends AnalyzerLineInserter   implements AnalyzerResponder {
+public class GenericASTMLineInserter extends AnalyzerLineInserter {
 
   /** The analyzer name for looking up test mappings */
   private final String analyzerName;
@@ -376,10 +375,5 @@ public class GenericASTMLineInserter extends AnalyzerLineInserter   implements A
 
     // Try short format
     return DateUtil.convertStringDateToTimestampWithPattern(timestampStr, ASTM_TIMESTAMP_SHORT);
-  }
-
-  @Override
-  public String buildResponse(List<String> lines) {
-    return this.analyzerName;
   }
 }

--- a/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMResponder.java
+++ b/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMResponder.java
@@ -1,0 +1,296 @@
+/**
+ * The contents of this file are subject to the Mozilla Public License Version 1.1 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at http://www.mozilla.org/MPL/
+ *
+ * <p>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF
+ * ANY KIND, either express or implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ *
+ * <p>The Original Code is OpenELIS code.
+ *
+ * <p>Copyright (C) CIRG, University of Washington, Seattle WA. All Rights Reserved.
+ */
+package org.openelisglobal.plugins.analyzer.genericastm;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.analyzerimport.analyzerreaders.AnalyzerResponder;
+import org.openelisglobal.analyzerimport.service.AnalyzerTestMappingService;
+import org.openelisglobal.analyzerimport.valueholder.AnalyzerTestMapping;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.person.valueholder.Person;
+import org.openelisglobal.sample.service.SampleService;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.openelisglobal.samplehuman.service.SampleHumanService;
+import org.openelisglobal.spring.util.SpringContext;
+import org.openelisglobal.test.valueholder.Test;
+
+/** Builds ASTM query responses for GenericASTM analyzers. */
+public class GenericASTMResponder implements AnalyzerResponder {
+
+  private static final String FIELD_DELIMITER = "|";
+  private static final String COMPONENT_DELIMITER = "^";
+  private static final String QUERY_SEGMENT_PREFIX = "Q|";
+
+  private static final String HEADER_TEMPLATE = "H|\\^&|||OpenELIS^OrderResponse^1.0|||||||LIS2-A2\r\n";
+  private static final String TERMINATOR_SEGMENT = "L|1|N\r\n";
+  private static final String NO_ORDER_SEGMENT_SUFFIX = "||||||||||||||||||||||||Y\r\n";
+
+  private final String analyzerTypeId;
+  private final String analyzerName;
+  private final SampleService sampleService;
+  private final SampleHumanService sampleHumanService;
+  private final AnalysisService analysisService;
+  private final AnalyzerTestMappingService analyzerTestMappingService;
+
+  private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd");
+  private final SimpleDateFormat dateTimeFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+
+  public GenericASTMResponder(String analyzerTypeId, String analyzerName) {
+    this(
+        analyzerTypeId,
+        analyzerName,
+        SpringContext.getBean(SampleService.class),
+        SpringContext.getBean(SampleHumanService.class),
+        SpringContext.getBean(AnalysisService.class),
+        SpringContext.getBean(AnalyzerTestMappingService.class));
+  }
+
+  GenericASTMResponder(
+      String analyzerTypeId,
+      String analyzerName,
+      SampleService sampleService,
+      SampleHumanService sampleHumanService,
+      AnalysisService analysisService,
+      AnalyzerTestMappingService analyzerTestMappingService) {
+    this.analyzerTypeId = analyzerTypeId;
+    this.analyzerName = analyzerName;
+    this.sampleService = sampleService;
+    this.sampleHumanService = sampleHumanService;
+    this.analysisService = analysisService;
+    this.analyzerTestMappingService = analyzerTestMappingService;
+  }
+
+  @Override
+  public String buildResponse(List<String> lines) {
+    if (lines == null || lines.isEmpty()) {
+      return "";
+    }
+
+    String queryRecord = findQueryRecord(lines);
+    if (queryRecord == null) {
+      LogEvent.logDebug(
+          this.getClass().getSimpleName(),
+          "buildResponse",
+          "No Q-record present; ignoring non-query message for " + analyzerName);
+      return "";
+    }
+
+    String requestedAccession = resolveRequestedAccession(queryRecord);
+    if (isBlank(requestedAccession)) {
+      LogEvent.logWarn(
+          this.getClass().getSimpleName(),
+          "buildResponse",
+          "Q-record present but accession identifier could not be resolved");
+      return "";
+    }
+
+    Sample sample = sampleService.getSampleByAccessionNumber(requestedAccession);
+    if (sample == null) {
+      LogEvent.logInfo(
+          this.getClass().getSimpleName(),
+          "buildResponse",
+          "No sample found for accession " + requestedAccession + "; returning no-order marker");
+      return buildNoOrderResponse(requestedAccession);
+    }
+
+    List<String> analyzerTestCodes = getMappedAnalyzerTestCodes(sample);
+    if (analyzerTestCodes.isEmpty()) {
+      LogEvent.logInfo(
+          this.getClass().getSimpleName(),
+          "buildResponse",
+          "Sample "
+              + requestedAccession
+              + " has no mapped tests for analyzer type "
+              + analyzerTypeId
+              + "; returning no-order marker");
+      return buildNoOrderResponse(requestedAccession);
+    }
+
+    Patient patient = sampleHumanService.getPatientForSample(sample);
+    return buildOrderResponse(requestedAccession, sample, patient, analyzerTestCodes);
+  }
+
+  private String findQueryRecord(List<String> lines) {
+    for (String line : lines) {
+      if (line != null && line.startsWith(QUERY_SEGMENT_PREFIX)) {
+        return line;
+      }
+    }
+    return null;
+  }
+
+  private String resolveRequestedAccession(String queryRecord) {
+    String[] queryFields = queryRecord.split("\\|", -1);
+    if (queryFields.length <= 2 || isBlank(queryFields[2])) {
+      return null;
+    }
+
+    String queryRangeField = queryFields[2].trim();
+    if (!queryRangeField.contains(COMPONENT_DELIMITER)) {
+      return queryRangeField;
+    }
+
+    String[] components = queryRangeField.split("\\^", -1);
+    List<String> candidates = new ArrayList<>();
+    for (String component : components) {
+      if (!isBlank(component)) {
+        String candidate = component.trim();
+        if (!candidates.contains(candidate)) {
+          candidates.add(candidate);
+        }
+      }
+    }
+
+    if (candidates.isEmpty()) {
+      return null;
+    }
+
+    // Devices differ in which Q.3 component carries accession. Prefer the first candidate that
+    // exists as a real sample; otherwise fall back to the first non-empty component.
+    for (String candidate : candidates) {
+      if (sampleService.getSampleByAccessionNumber(candidate) != null) {
+        return candidate;
+      }
+    }
+
+    return candidates.get(0);
+  }
+
+  private List<String> getMappedAnalyzerTestCodes(Sample sample) {
+    List<Analysis> analyses = analysisService.getAnalysesBySampleId(sample.getId());
+    if (analyses == null || analyses.isEmpty()) {
+      return new ArrayList<>();
+    }
+
+    Map<String, List<String>> testIdToAnalyzerCodes = buildTestIdToAnalyzerCodesMap();
+    Set<String> orderedCodes = new LinkedHashSet<>();
+
+    for (Analysis analysis : analyses) {
+      Test test = analysis.getTest();
+      if (test == null || isBlank(test.getId())) {
+        continue;
+      }
+
+      List<String> analyzerCodes = testIdToAnalyzerCodes.get(test.getId());
+      if (analyzerCodes != null) {
+        orderedCodes.addAll(analyzerCodes);
+      }
+    }
+
+    return new ArrayList<>(orderedCodes);
+  }
+
+  private Map<String, List<String>> buildTestIdToAnalyzerCodesMap() {
+    List<AnalyzerTestMapping> mappings = analyzerTestMappingService.getAll();
+    Map<String, List<String>> testIdToCodes = new LinkedHashMap<>();
+
+    for (AnalyzerTestMapping mapping : mappings) {
+      if (!analyzerTypeId.equals(mapping.getAnalyzerTypeId())
+          || isBlank(mapping.getTestId())
+          || isBlank(mapping.getAnalyzerTestName())) {
+        continue;
+      }
+
+      testIdToCodes.computeIfAbsent(mapping.getTestId(), key -> new ArrayList<>());
+      List<String> analyzerCodes = testIdToCodes.get(mapping.getTestId());
+      if (!analyzerCodes.contains(mapping.getAnalyzerTestName())) {
+        analyzerCodes.add(mapping.getAnalyzerTestName());
+      }
+    }
+
+    return testIdToCodes;
+  }
+
+  private String buildOrderResponse(
+      String accessionNumber, Sample sample, Patient patient, List<String> analyzerTestCodes) {
+    String patientId = "";
+    String patientName = "";
+    String birthDate = "";
+    String gender = "";
+
+    if (patient != null) {
+      patientId = safe(patient.getNationalId());
+      gender = safe(patient.getGender());
+      if (patient.getBirthDate() != null) {
+        birthDate = dateFormat.format(patient.getBirthDate());
+      }
+
+      Person person = patient.getPerson();
+      if (person != null) {
+        patientName = safe(person.getLastName()) + "^" + safe(person.getFirstName());
+      }
+    }
+
+    String orderTimestamp =
+        sample.getEnteredDate() != null
+            ? dateTimeFormat.format(sample.getEnteredDate())
+            : dateTimeFormat.format(new Date());
+    String orderTestField =
+        analyzerTestCodes.stream()
+            .map(code -> "^^^" + code)
+            .collect(Collectors.joining("\\"));
+
+    StringBuilder response = new StringBuilder();
+    response.append(HEADER_TEMPLATE);
+    response
+        .append("P|1|")
+        .append(patientId)
+        .append("||")
+        .append(patientName)
+        .append("||")
+        .append(birthDate)
+        .append("|")
+        .append(gender)
+        .append("\r\n");
+
+    response
+        .append("O|1|")
+        .append(accessionNumber)
+        .append("||")
+        .append(orderTestField)
+        .append("|R|")
+        .append(orderTimestamp)
+        .append("||||A\r\n");
+    response.append(TERMINATOR_SEGMENT);
+    return response.toString();
+  }
+
+  private String buildNoOrderResponse(String accessionNumber) {
+    StringBuilder response = new StringBuilder();
+    response.append(HEADER_TEMPLATE);
+    response.append("P|1|\r\n");
+    response.append("O|1|").append(accessionNumber).append(NO_ORDER_SEGMENT_SUFFIX);
+    response.append(TERMINATOR_SEGMENT);
+    return response.toString();
+  }
+
+  private String safe(String value) {
+    return value == null ? "" : value.trim();
+  }
+
+  private boolean isBlank(String value) {
+    return value == null || value.trim().isEmpty();
+  }
+}

--- a/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMResponder.java
+++ b/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMResponder.java
@@ -13,9 +13,11 @@
  */
 package org.openelisglobal.plugins.analyzer.genericastm;
 
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -56,15 +58,17 @@ public class GenericASTMResponder implements AnalyzerResponder {
     }
   }
 
+  private static final String RESPONSE_TIMEZONE_PROPERTY = "org.openelisglobal.plugins.genericastm.response-timezone";
+  private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+  private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
   private final String analyzerTypeId;
   private final String analyzerName;
   private final SampleService sampleService;
   private final SampleHumanService sampleHumanService;
   private final AnalysisService analysisService;
   private final AnalyzerTestMappingService analyzerTestMappingService;
-
-  private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd");
-  private final SimpleDateFormat dateTimeFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+  private final ZoneId responseZoneId;
 
   public GenericASTMResponder(String analyzerTypeId, String analyzerName) {
     this(
@@ -89,6 +93,22 @@ public class GenericASTMResponder implements AnalyzerResponder {
     this.sampleHumanService = sampleHumanService;
     this.analysisService = analysisService;
     this.analyzerTestMappingService = analyzerTestMappingService;
+    this.responseZoneId = resolveResponseZoneId();
+  }
+
+  private static ZoneId resolveResponseZoneId() {
+    String tz = System.getProperty(RESPONSE_TIMEZONE_PROPERTY);
+    if (tz != null && !tz.trim().isEmpty()) {
+      try {
+        return ZoneId.of(tz.trim());
+      } catch (Exception e) {
+        LogEvent.logWarn(
+            GenericASTMResponder.class.getSimpleName(),
+            "resolveResponseZoneId",
+            "Invalid " + RESPONSE_TIMEZONE_PROPERTY + "='" + tz + "', using UTC");
+      }
+    }
+    return ZoneId.of("UTC");
   }
 
   @Override
@@ -166,15 +186,13 @@ public class GenericASTMResponder implements AnalyzerResponder {
     }
 
     String[] components = queryRangeField.split("\\^", -1);
-    List<String> candidates = new ArrayList<>();
+    Set<String> candidateSet = new LinkedHashSet<>();
     for (String component : components) {
       if (!isBlank(component)) {
-        String candidate = component.trim();
-        if (!candidates.contains(candidate)) {
-          candidates.add(candidate);
-        }
+        candidateSet.add(component.trim());
       }
     }
+    List<String> candidates = new ArrayList<>(candidateSet);
 
     if (candidates.isEmpty()) {
       return null;
@@ -245,25 +263,32 @@ public class GenericASTMResponder implements AnalyzerResponder {
     String gender = "";
 
     if (patient != null) {
-      patientId = safe(patient.getNationalId());
-      gender = safe(patient.getGender());
+      patientId = sanitizeAstmField(safe(patient.getNationalId()));
+      gender = sanitizeAstmField(safe(patient.getGender()));
       if (patient.getBirthDate() != null) {
-        birthDate = dateFormat.format(patient.getBirthDate());
+        birthDate =
+            DATE_FORMAT.format(
+                Instant.ofEpochMilli(patient.getBirthDate().getTime())
+                    .atZone(responseZoneId)
+                    .toLocalDate());
       }
 
       Person person = patient.getPerson();
       if (person != null) {
-        patientName = safe(person.getLastName()) + "^" + safe(person.getFirstName());
+        patientName =
+            sanitizeAstmField(safe(person.getLastName())) + "^"
+                + sanitizeAstmField(safe(person.getFirstName()));
       }
     }
 
-    String orderTimestamp =
+    ZonedDateTime orderTime =
         sample.getEnteredDate() != null
-            ? dateTimeFormat.format(sample.getEnteredDate())
-            : dateTimeFormat.format(new Date());
+            ? Instant.ofEpochMilli(sample.getEnteredDate().getTime()).atZone(responseZoneId)
+            : ZonedDateTime.now(responseZoneId);
+    String orderTimestamp = DATE_TIME_FORMAT.format(orderTime);
     String orderTestField =
         analyzerTestCodes.stream()
-            .map(code -> "^^^" + code)
+            .map(code -> "^^^" + sanitizeAstmField(code))
             .collect(Collectors.joining("\\"));
 
     StringBuilder response = new StringBuilder();
@@ -281,7 +306,7 @@ public class GenericASTMResponder implements AnalyzerResponder {
 
     response
         .append("O|1|")
-        .append(accessionNumber)
+        .append(sanitizeAstmField(accessionNumber))
         .append("||")
         .append(orderTestField)
         .append("|R|")
@@ -295,7 +320,7 @@ public class GenericASTMResponder implements AnalyzerResponder {
     StringBuilder response = new StringBuilder();
     response.append(HEADER_TEMPLATE);
     response.append("P|1|\r\n");
-    response.append("O|1|").append(accessionNumber).append(NO_ORDER_SEGMENT_SUFFIX);
+    response.append("O|1|").append(sanitizeAstmField(accessionNumber)).append(NO_ORDER_SEGMENT_SUFFIX);
     response.append(TERMINATOR_SEGMENT);
     return response.toString();
   }
@@ -306,5 +331,21 @@ public class GenericASTMResponder implements AnalyzerResponder {
 
   private boolean isBlank(String value) {
     return value == null || value.trim().isEmpty();
+  }
+
+  /**
+   * Sanitizes a value for use in ASTM outbound fields. ASTM uses {@code |}, {@code ^}, {@code \},
+   * {@code &} as delimiters; values containing these can break message structure. Replaces
+   * delimiter chars with space to produce valid output.
+   */
+  private String sanitizeAstmField(String value) {
+    if (value == null || value.isEmpty()) {
+      return value == null ? "" : value;
+    }
+    return value.replace('|', ' ')
+        .replace('^', ' ')
+        .replace('\\', ' ')
+        .replace('&', ' ')
+        .trim();
   }
 }

--- a/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMResponder.java
+++ b/analyzers/GenericASTM/src/main/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMResponder.java
@@ -39,13 +39,22 @@ import org.openelisglobal.test.valueholder.Test;
 /** Builds ASTM query responses for GenericASTM analyzers. */
 public class GenericASTMResponder implements AnalyzerResponder {
 
-  private static final String FIELD_DELIMITER = "|";
   private static final String COMPONENT_DELIMITER = "^";
   private static final String QUERY_SEGMENT_PREFIX = "Q|";
 
   private static final String HEADER_TEMPLATE = "H|\\^&|||OpenELIS^OrderResponse^1.0|||||||LIS2-A2\r\n";
   private static final String TERMINATOR_SEGMENT = "L|1|N\r\n";
   private static final String NO_ORDER_SEGMENT_SUFFIX = "||||||||||||||||||||||||Y\r\n";
+
+  private static final class ResolvedAccession {
+    private final String accessionNumber;
+    private final Sample sample;
+
+    private ResolvedAccession(String accessionNumber, Sample sample) {
+      this.accessionNumber = accessionNumber;
+      this.sample = sample;
+    }
+  }
 
   private final String analyzerTypeId;
   private final String analyzerName;
@@ -97,8 +106,8 @@ public class GenericASTMResponder implements AnalyzerResponder {
       return "";
     }
 
-    String requestedAccession = resolveRequestedAccession(queryRecord);
-    if (isBlank(requestedAccession)) {
+    ResolvedAccession resolvedAccession = resolveRequestedAccession(queryRecord);
+    if (resolvedAccession == null || isBlank(resolvedAccession.accessionNumber)) {
       LogEvent.logWarn(
           this.getClass().getSimpleName(),
           "buildResponse",
@@ -106,7 +115,11 @@ public class GenericASTMResponder implements AnalyzerResponder {
       return "";
     }
 
-    Sample sample = sampleService.getSampleByAccessionNumber(requestedAccession);
+    String requestedAccession = resolvedAccession.accessionNumber;
+    Sample sample =
+        resolvedAccession.sample != null
+            ? resolvedAccession.sample
+            : sampleService.getSampleByAccessionNumber(requestedAccession);
     if (sample == null) {
       LogEvent.logInfo(
           this.getClass().getSimpleName(),
@@ -141,7 +154,7 @@ public class GenericASTMResponder implements AnalyzerResponder {
     return null;
   }
 
-  private String resolveRequestedAccession(String queryRecord) {
+  private ResolvedAccession resolveRequestedAccession(String queryRecord) {
     String[] queryFields = queryRecord.split("\\|", -1);
     if (queryFields.length <= 2 || isBlank(queryFields[2])) {
       return null;
@@ -149,7 +162,7 @@ public class GenericASTMResponder implements AnalyzerResponder {
 
     String queryRangeField = queryFields[2].trim();
     if (!queryRangeField.contains(COMPONENT_DELIMITER)) {
-      return queryRangeField;
+      return new ResolvedAccession(queryRangeField, null);
     }
 
     String[] components = queryRangeField.split("\\^", -1);
@@ -170,12 +183,13 @@ public class GenericASTMResponder implements AnalyzerResponder {
     // Devices differ in which Q.3 component carries accession. Prefer the first candidate that
     // exists as a real sample; otherwise fall back to the first non-empty component.
     for (String candidate : candidates) {
-      if (sampleService.getSampleByAccessionNumber(candidate) != null) {
-        return candidate;
+      Sample sample = sampleService.getSampleByAccessionNumber(candidate);
+      if (sample != null) {
+        return new ResolvedAccession(candidate, sample);
       }
     }
 
-    return candidates.get(0);
+    return new ResolvedAccession(candidates.get(0), null);
   }
 
   private List<String> getMappedAnalyzerTestCodes(Sample sample) {

--- a/analyzers/GenericASTM/src/test/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMResponderTest.java
+++ b/analyzers/GenericASTM/src/test/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMResponderTest.java
@@ -1,0 +1,121 @@
+package org.openelisglobal.plugins.analyzer.genericastm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.analyzerimport.service.AnalyzerTestMappingService;
+import org.openelisglobal.analyzerimport.valueholder.AnalyzerTestMapping;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.person.valueholder.Person;
+import org.openelisglobal.sample.service.SampleService;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.openelisglobal.samplehuman.service.SampleHumanService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GenericASTMResponderTest {
+
+  private static final String ANALYZER_TYPE_ID = "2006";
+  private static final String ANALYZER_NAME = "GenericASTM";
+
+  @Mock private SampleService sampleService;
+  @Mock private SampleHumanService sampleHumanService;
+  @Mock private AnalysisService analysisService;
+  @Mock private AnalyzerTestMappingService analyzerTestMappingService;
+
+  private GenericASTMResponder responder;
+
+  @Before
+  public void setUp() {
+    responder =
+        new GenericASTMResponder(
+            ANALYZER_TYPE_ID,
+            ANALYZER_NAME,
+            sampleService,
+            sampleHumanService,
+            analysisService,
+            analyzerTestMappingService);
+  }
+
+  @Test
+  public void buildResponse_WithQRecordAndMappedAnalysis_ReturnsProtocolOrderSegments() {
+    String accessionNumber = "GX-2026-0001";
+    Sample sample = org.mockito.Mockito.mock(Sample.class);
+    when(sample.getId()).thenReturn("sample-1");
+    when(sample.getEnteredDate()).thenReturn(new java.sql.Date(1741262400000L));
+
+    Person person = org.mockito.Mockito.mock(Person.class);
+    when(person.getFirstName()).thenReturn("Jean");
+    when(person.getLastName()).thenReturn("Rakoto");
+
+    Patient patient = org.mockito.Mockito.mock(Patient.class);
+    when(patient.getNationalId()).thenReturn("PAT-001");
+    when(patient.getGender()).thenReturn("M");
+    when(patient.getBirthDate()).thenReturn(new Timestamp(479001600000L));
+    when(patient.getPerson()).thenReturn(person);
+
+    org.openelisglobal.test.valueholder.Test test =
+        org.mockito.Mockito.mock(org.openelisglobal.test.valueholder.Test.class);
+    when(test.getId()).thenReturn("101");
+    Analysis analysis = org.mockito.Mockito.mock(Analysis.class);
+    when(analysis.getTest()).thenReturn(test);
+
+    AnalyzerTestMapping mapping = new AnalyzerTestMapping();
+    mapping.setAnalyzerTypeId(ANALYZER_TYPE_ID);
+    mapping.setAnalyzerTestName("MTB-RIF");
+    mapping.setTestId("101");
+
+    when(sampleService.getSampleByAccessionNumber(accessionNumber)).thenReturn(sample);
+    when(sampleHumanService.getPatientForSample(sample)).thenReturn(patient);
+    when(analysisService.getAnalysesBySampleId("sample-1")).thenReturn(Collections.singletonList(analysis));
+    when(analyzerTestMappingService.getAll()).thenReturn(Collections.singletonList(mapping));
+
+    List<String> lines =
+        Arrays.asList(
+            "H|\\^&|||GENEXPERT^GeneXpert^4.6.0|||||||LIS2-A2",
+            "Q|1|" + accessionNumber + "||ALL",
+            "L|1|N");
+
+    String response = responder.buildResponse(lines);
+
+    assertTrue("Response should start with ASTM header", response.startsWith("H|\\^&"));
+    assertTrue("Response should contain patient segment", response.contains("P|1|PAT-001||Rakoto^Jean"));
+    assertTrue(
+        "Response should include mapped analyzer test code in O record",
+        response.contains("O|1|GX-2026-0001||^^^MTB-RIF|R|"));
+    assertTrue("Response should end with ASTM terminator", response.endsWith("L|1|N\r\n"));
+  }
+
+  @Test
+  public void buildResponse_WithQRecordAndUnknownSample_ReturnsNoOrderMarker() {
+    when(sampleService.getSampleByAccessionNumber("UNKNOWN-01")).thenReturn(null);
+
+    List<String> lines =
+        Arrays.asList(
+            "H|\\^&|||GENEXPERT^GeneXpert^4.6.0|||||||LIS2-A2", "Q|1|UNKNOWN-01||ALL", "L|1|N");
+
+    String response = responder.buildResponse(lines);
+
+    assertTrue("No-order response should contain O-record no-order marker", response.contains("|Y\r\n"));
+    assertTrue("No-order response should include requested accession", response.contains("O|1|UNKNOWN-01"));
+  }
+
+  @Test
+  public void buildResponse_WithoutQRecord_ReturnsEmptyString() {
+    List<String> lines =
+        Arrays.asList("H|\\^&|||GENEXPERT^GeneXpert^4.6.0|||||||LIS2-A2", "L|1|N");
+
+    assertEquals("", responder.buildResponse(lines));
+  }
+}

--- a/analyzers/GenericASTM/src/test/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMResponderTest.java
+++ b/analyzers/GenericASTM/src/test/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMResponderTest.java
@@ -202,4 +202,51 @@ public class GenericASTMResponderTest {
 
     assertTrue(response.contains("O|1|" + accessionNumber + "||^^^MTB-RIF\\^^^XDR|R|"));
   }
+
+  @Test
+  public void buildResponse_WithDelimiterCharsInPatientData_SanitizesOutboundFields() {
+    String accessionNumber = "GX-2026-0004";
+    Sample sample = org.mockito.Mockito.mock(Sample.class);
+    when(sample.getId()).thenReturn("sample-4");
+    when(sample.getEnteredDate()).thenReturn(new java.sql.Date(1741262400000L));
+
+    Person person = org.mockito.Mockito.mock(Person.class);
+    when(person.getFirstName()).thenReturn("Jean|Pierre");
+    when(person.getLastName()).thenReturn("O'Brien^Smith");
+
+    Patient patient = org.mockito.Mockito.mock(Patient.class);
+    when(patient.getNationalId()).thenReturn("PAT|001");
+    when(patient.getGender()).thenReturn("M");
+    when(patient.getBirthDate()).thenReturn(new Timestamp(479001600000L));
+    when(patient.getPerson()).thenReturn(person);
+
+    org.openelisglobal.test.valueholder.Test test =
+        org.mockito.Mockito.mock(org.openelisglobal.test.valueholder.Test.class);
+    when(test.getId()).thenReturn("101");
+    Analysis analysis = org.mockito.Mockito.mock(Analysis.class);
+    when(analysis.getTest()).thenReturn(test);
+
+    AnalyzerTestMapping mapping = new AnalyzerTestMapping();
+    mapping.setAnalyzerTypeId(ANALYZER_TYPE_ID);
+    mapping.setAnalyzerTestName("MTB-RIF");
+    mapping.setTestId("101");
+
+    when(sampleService.getSampleByAccessionNumber(accessionNumber)).thenReturn(sample);
+    when(sampleHumanService.getPatientForSample(sample)).thenReturn(patient);
+    when(analysisService.getAnalysesBySampleId("sample-4")).thenReturn(Collections.singletonList(analysis));
+    when(analyzerTestMappingService.getAll()).thenReturn(Collections.singletonList(mapping));
+
+    List<String> lines =
+        Arrays.asList(
+            "H|\\^&|||GENEXPERT^GeneXpert^4.6.0|||||||LIS2-A2",
+            "Q|1|" + accessionNumber + "||ALL",
+            "L|1|N");
+
+    String response = responder.buildResponse(lines);
+
+    assertTrue("Response should not contain raw pipe in patient segment", !response.contains("PAT|001"));
+    assertTrue("Response should sanitize patient ID", response.contains("PAT 001"));
+    assertTrue("Response should sanitize patient name delimiters", response.contains("O'Brien Smith"));
+    assertTrue("Response should contain P segment", response.contains("P|1|"));
+  }
 }

--- a/analyzers/GenericASTM/src/test/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMResponderTest.java
+++ b/analyzers/GenericASTM/src/test/java/org/openelisglobal/plugins/analyzer/genericastm/GenericASTMResponderTest.java
@@ -2,6 +2,8 @@ package org.openelisglobal.plugins.analyzer.genericastm;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
@@ -117,5 +119,87 @@ public class GenericASTMResponderTest {
         Arrays.asList("H|\\^&|||GENEXPERT^GeneXpert^4.6.0|||||||LIS2-A2", "L|1|N");
 
     assertEquals("", responder.buildResponse(lines));
+  }
+
+  @Test
+  public void buildResponse_WithCaretDelimitedAccession_UsesMatchingComponentWithoutDuplicateLookup() {
+    String accessionNumber = "GX-2026-0002";
+    Sample sample = org.mockito.Mockito.mock(Sample.class);
+    when(sample.getId()).thenReturn("sample-2");
+    when(sample.getEnteredDate()).thenReturn(new java.sql.Date(1741262400000L));
+
+    org.openelisglobal.test.valueholder.Test test =
+        org.mockito.Mockito.mock(org.openelisglobal.test.valueholder.Test.class);
+    when(test.getId()).thenReturn("101");
+    Analysis analysis = org.mockito.Mockito.mock(Analysis.class);
+    when(analysis.getTest()).thenReturn(test);
+
+    AnalyzerTestMapping mapping = new AnalyzerTestMapping();
+    mapping.setAnalyzerTypeId(ANALYZER_TYPE_ID);
+    mapping.setAnalyzerTestName("MTB-RIF");
+    mapping.setTestId("101");
+
+    when(sampleService.getSampleByAccessionNumber("ALT-ID")).thenReturn(null);
+    when(sampleService.getSampleByAccessionNumber(accessionNumber)).thenReturn(sample);
+    when(analysisService.getAnalysesBySampleId("sample-2"))
+        .thenReturn(Collections.singletonList(analysis));
+    when(analyzerTestMappingService.getAll()).thenReturn(Collections.singletonList(mapping));
+
+    List<String> lines =
+        Arrays.asList(
+            "H|\\^&|||GENEXPERT^GeneXpert^4.6.0|||||||LIS2-A2",
+            "Q|1|ALT-ID^" + accessionNumber + "^IGNORED||ALL",
+            "L|1|N");
+
+    String response = responder.buildResponse(lines);
+
+    assertTrue(response.contains("O|1|" + accessionNumber + "||^^^MTB-RIF|R|"));
+    verify(sampleService).getSampleByAccessionNumber("ALT-ID");
+    verify(sampleService, times(1)).getSampleByAccessionNumber(accessionNumber);
+  }
+
+  @Test
+  public void buildResponse_WithMultipleMappedAnalyzerCodes_JoinsCodesInOrderRecord() {
+    String accessionNumber = "GX-2026-0003";
+    Sample sample = org.mockito.Mockito.mock(Sample.class);
+    when(sample.getId()).thenReturn("sample-3");
+    when(sample.getEnteredDate()).thenReturn(new java.sql.Date(1741262400000L));
+
+    org.openelisglobal.test.valueholder.Test firstTest =
+        org.mockito.Mockito.mock(org.openelisglobal.test.valueholder.Test.class);
+    when(firstTest.getId()).thenReturn("101");
+    Analysis firstAnalysis = org.mockito.Mockito.mock(Analysis.class);
+    when(firstAnalysis.getTest()).thenReturn(firstTest);
+
+    org.openelisglobal.test.valueholder.Test secondTest =
+        org.mockito.Mockito.mock(org.openelisglobal.test.valueholder.Test.class);
+    when(secondTest.getId()).thenReturn("102");
+    Analysis secondAnalysis = org.mockito.Mockito.mock(Analysis.class);
+    when(secondAnalysis.getTest()).thenReturn(secondTest);
+
+    AnalyzerTestMapping firstMapping = new AnalyzerTestMapping();
+    firstMapping.setAnalyzerTypeId(ANALYZER_TYPE_ID);
+    firstMapping.setAnalyzerTestName("MTB-RIF");
+    firstMapping.setTestId("101");
+
+    AnalyzerTestMapping secondMapping = new AnalyzerTestMapping();
+    secondMapping.setAnalyzerTypeId(ANALYZER_TYPE_ID);
+    secondMapping.setAnalyzerTestName("XDR");
+    secondMapping.setTestId("102");
+
+    when(sampleService.getSampleByAccessionNumber(accessionNumber)).thenReturn(sample);
+    when(analysisService.getAnalysesBySampleId("sample-3"))
+        .thenReturn(Arrays.asList(firstAnalysis, secondAnalysis));
+    when(analyzerTestMappingService.getAll()).thenReturn(Arrays.asList(firstMapping, secondMapping));
+
+    List<String> lines =
+        Arrays.asList(
+            "H|\\^&|||GENEXPERT^GeneXpert^4.6.0|||||||LIS2-A2",
+            "Q|1|" + accessionNumber + "||ALL",
+            "L|1|N");
+
+    String response = responder.buildResponse(lines);
+
+    assertTrue(response.contains("O|1|" + accessionNumber + "||^^^MTB-RIF\\^^^XDR|R|"));
   }
 }

--- a/analyzers/GenericASTM/src/test/resources/testdata/test-result.xml
+++ b/analyzers/GenericASTM/src/test/resources/testdata/test-result.xml
@@ -1,11 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dataset>
-    <localization id="1" description="Test Description 1"
-        english="TB" french="TB" />
-    <localization id="2" description="Test Description 2"
-        english="Urinalysis" french="Urinalysis" />
-    <localization id="3" description="Test Description 3"
-        english="blood test" french="Merci" />
+    <localization id="1" description="Test Description 1" />
+    <localization id="2" description="Test Description 2" />
+    <localization id="3" description="Test Description 3" />
+    <localization_value id="1" localization_id="1"
+        locale="en" value="TB" />
+    <localization_value id="2" localization_id="1"
+        locale="fr" value="TB" />
+    <localization_value id="3" localization_id="2"
+        locale="en" value="Urinalysis" />
+    <localization_value id="4" localization_id="2"
+        locale="fr" value="Urinalysis" />
+    <localization_value id="5" localization_id="3"
+        locale="en" value="blood test" />
+    <localization_value id="6" localization_id="3"
+        locale="fr" value="Merci" />
+    <supported_locale id="1" locale_code="en"
+        display_name="English" is_active="true" is_fallback="true"
+        sort_order="1" />
+    <supported_locale id="2" locale_code="fr"
+        display_name="Français" is_active="true" is_fallback="false"
+        sort_order="2" />
 
     <unit_of_measure id="1" name="mg/dL"
         description="Milligrams per deciliter" />


### PR DESCRIPTION
## Summary
- add `GenericASTMResponder` to handle ASTM Q-record query responses on the existing `AnalyzerResponder` path
- wire `GenericASTMAnalyzer` to return the dedicated responder while keeping `GenericASTMLineInserter` focused on result ingest
- add responder unit tests and update GenericASTM test fixture localization schema for current DBUnit expectations

## Test plan
- [x] `mvn -Dtest=GenericASTMResponderTest,GenericASTMIntegrationTest test` (run in `plugins/analyzers/GenericASTM`)
- [x] verify Q-record and non-query routing behavior in new responder tests

Made with [Cursor](https://cursor.com)