### PR TITLE
feat(analyzer): Add Erba Mannheim Hematology Analyzer Plugin (H360, H560, ELite 580)

### DIFF
--- a/analyzers/ErbaHematology/ORU_R01.md
+++ b/analyzers/ErbaHematology/ORU_R01.md
@@ -1,0 +1,159 @@
+# Sample HL7 Messages
+
+These are representative HL7 v2.3.1 ORU^R01 messages for each analyzer model.
+Patient details are fictitious. Accession numbers are illustrative only.
+
+---
+
+## H360 - CBC+3DIFF
+
+```
+MSH|^~\&|H360|Erba|||20260101080000||ORU^R01|H360_20260101_080000_001|P|2.3.1||||||UNICODE
+PID|1||100001^^^^MR||^TEST PATIENT||19900101000000|Male
+PV1|1
+OBR|1||100001|01001^Automated Count^99MRC||20260101075800|20260101080000|||||||20260101080000||||||||||HM||||||||admin
+OBX|1|IS|02001^Take Mode^99MRC||O||||||F
+OBX|2|IS|02002^Blood Mode^99MRC||W||||||F
+OBX|3|IS|02003^Test Mode^99MRC||CBC+3DIFF||||||F
+OBX|4|NM|30525-0^Age^LN||35|yr|||||F
+OBX|5|IS|09001^Remark^99MRC||||||||F
+OBX|6|IS|03001^Ref Group^99MRC||General||||||F
+OBX|7|NM|6690-2^WBC^LN||7.50|10*3/uL|3.50-9.50|~N|||F
+OBX|8|NM|736-9^LYM%^LN||30.0|%|20.0-50.0|~N|||F
+OBX|9|NM|20482-6^GRAN%^LN||62.0|%|50.0-70.0|~N|||F
+OBX|10|NM|32155-4^MID%^LN||8.0|%|3.0-9.0|~N|||F
+OBX|11|NM|731-0^LYM#^LN||2.25|10*3/uL|1.10-3.20|~N|||F
+OBX|12|NM|19023-1^GRAN#^LN||4.65|10*3/uL|2.00-7.00|~N|||F
+OBX|13|NM|32154-7^MID#^LN||0.60|10*3/uL|0.10-0.90|~N|||F
+OBX|14|NM|789-8^RBC^LN||4.80|10*6/uL|3.80-5.80|~N|||F
+OBX|15|NM|718-7^HGB^LN||14.5|g/dL|11.5-17.5|~N|||F
+OBX|16|NM|4544-3^HCT^LN||43.0|%|35.0-50.0|~N|||F
+OBX|17|NM|787-2^MCV^LN||89.6|fL|82.0-100.0|~N|||F
+OBX|18|NM|785-6^MCH^LN||30.2|pg|27.0-34.0|~N|||F
+OBX|19|NM|786-4^MCHC^LN||33.7|g/dL|31.6-35.4|~N|||F
+OBX|20|NM|788-0^RDW-CV^LN||13.0|%|11.5-14.5|~N|||F
+OBX|21|NM|21000-5^RDW-SD^LN||42.0|fL|35.0-56.0|~N|||F
+OBX|22|NM|11092^*Mentzr^LN||18.67|||~N|||F
+OBX|23|NM|11093^*RDWI^LN||201.60|||~N|||F
+OBX|24|NM|777-3^PLT^LN||220|10*3/uL|125-350|~N|||F
+OBX|25|NM|32623-1^MPV^LN||9.5|fL|7.0-11.0|~N|||F
+OBX|26|NM|32207-3^PDW-SD^LN||12.5|fL|9.0-17.0|~N|||F
+OBX|27|NM|11090^PDW-CV^LN||14.0|%|10.0-17.9|~N|||F
+OBX|28|NM|11003^PCT^99MRC||0.209|%|0.108-0.282|~N|||F
+OBX|29|NM|48386-7^P-LCR^LN||25.0|%|11.0-45.0|~N|||F
+OBX|30|NM|34167-7^P-LCC^LN||55|10*3/uL|30-90|~N|||F
+```
+
+**Notes:**
+- MSH-3: `H360`
+- Test mode: `CBC+3DIFF` - 3-part differential (GRAN, MID, LYM)
+- No NEU/MON/EOS/BAS - those are 5-part only
+- Mentzer and RDWI present (observed in real H360 messages)
+- PDW sent as two segments: PDW-SD and PDW-CV
+
+---
+
+## H560 - CBC+DIFF (5-part)
+
+```
+MSH|^~\&|H560|Erba|||20260101080000||ORU^R01|H560_20260101_080000_001|P|2.3.1||||||UNICODE
+PID|1||100002^^^^MR||^TEST PATIENT||19850615000000|Female
+PV1|1
+OBR|1||100002|01001^Automated Count^99MRC||20260101075800|20260101080000|||||||20260101080000||||||||||HM||||||||admin
+OBX|1|IS|02001^Take Mode^99MRC||O||||||F
+OBX|2|IS|02002^Blood Mode^99MRC||W||||||F
+OBX|3|IS|02003^Test Mode^99MRC||CBC+DIFF||||||F
+OBX|4|NM|30525-0^Age^LN||40|yr|||||F
+OBX|5|IS|09001^Remark^99MRC||||||||F
+OBX|6|IS|03001^Ref Group^99MRC||General||||||F
+OBX|7|NM|6690-2^WBC^LN||6.80|10*3/uL|3.50-9.50|~N|||F
+OBX|8|NM|770-8^NEU%^LN||58.0|%|50.0-70.0|~N|||F
+OBX|9|NM|736-9^LYM%^LN||32.0|%|20.0-40.0|~N|||F
+OBX|10|NM|5905-5^MON%^LN||7.0|%|3.0-12.0|~N|||F
+OBX|11|NM|713-8^EOS%^LN||2.5|%|0.5-5.0|~N|||F
+OBX|12|NM|706-2^BAS%^LN||0.5|%|0.0-1.0|~N|||F
+OBX|13|NM|751-8^NEU#^LN||3.94|10*3/uL|2.00-7.00|~N|||F
+OBX|14|NM|731-0^LYM#^LN||2.18|10*3/uL|0.80-4.00|~N|||F
+OBX|15|NM|742-7^MON#^LN||0.48|10*3/uL|0.12-1.20|~N|||F
+OBX|16|NM|711-2^EOS#^LN||0.17|10*3/uL|0.02-0.50|~N|||F
+OBX|17|NM|704-7^BAS#^LN||0.03|10*3/uL|0.00-0.10|~N|||F
+OBX|18|NM|789-8^RBC^LN||4.50|10*6/uL|3.80-5.80|~N|||F
+OBX|19|NM|718-7^HGB^LN||13.5|g/dL|11.5-17.5|~N|||F
+OBX|20|NM|4544-3^HCT^LN||40.5|%|35.0-50.0|~N|||F
+OBX|21|NM|787-2^MCV^LN||90.0|fL|82.0-100.0|~N|||F
+OBX|22|NM|785-6^MCH^LN||30.0|pg|27.0-34.0|~N|||F
+OBX|23|NM|786-4^MCHC^LN||33.3|g/dL|31.6-35.4|~N|||F
+OBX|24|NM|788-0^RDW-CV^LN||13.2|%|11.0-16.0|~N|||F
+OBX|25|NM|21000-5^RDW-SD^LN||43.0|fL|35.0-56.0|~N|||F
+OBX|26|NM|777-3^PLT^LN||240|10*3/uL|125-350|~N|||F
+OBX|27|NM|32623-1^MPV^LN||9.8|fL|6.5-12.0|~N|||F
+OBX|28|NM|32207-3^PDW-SD^LN||13.0|fL|9.0-17.0|~N|||F
+OBX|29|NM|11090^PDW-CV^LN||15.0|%|10.0-17.9|~N|||F
+OBX|30|NM|11003^PCT^99MRC||0.235|%|0.108-0.282|~N|||F
+OBX|31|NM|48386-7^P-LCR^LN||28.0|%|11.0-45.0|~N|||F
+OBX|32|NM|34167-7^P-LCC^LN||67|10*3/uL|30-90|~N|||F
+```
+
+**Notes:**
+- MSH-3: `H560`
+- Test mode: `CBC+DIFF` - full 5-part differential
+- No GRAN/MID - those are 3-part (H360) only
+- No ALY/LIC - those are ELite 580 only
+- Mentzer and RDWI not included - unconfirmed on H560
+
+---
+
+## ELite 580 - CBC+DIFF (5-part + extended)
+
+```
+MSH|^~\&|ELite 580|Erba|||20260101080000||ORU^R01|ELITE_20260101_080000_001|P|2.3.1||||||UNICODE
+PID|1||100003^^^^MR||^TEST PATIENT||19951120000000|Female
+PV1|1
+OBR|1||100003|01001^Automated Count^99MRC||20260101075800|20260101080000|||||||20260101080000||||||||||HM||||||||admin
+OBX|1|IS|02001^Take Mode^99MRC||O||||||F
+OBX|2|IS|02002^Blood Mode^99MRC||W||||||F
+OBX|3|IS|02003^Test Mode^99MRC||CBC+DIFF||||||F
+OBX|4|NM|30525-0^Age^LN||30|yr|||||F
+OBX|5|IS|09001^Remark^99MRC||||||||F
+OBX|6|IS|03001^Ref Group^99MRC||General||||||F
+OBX|7|NM|6690-2^WBC^LN||7.20|10*3/uL|4.00-10.00|~N|||F
+OBX|8|NM|770-8^NEU%^LN||55.0|%|50.0-70.0|~N|||F
+OBX|9|NM|736-9^LYM%^LN||36.0|%|20.0-40.0|~N|||F
+OBX|10|NM|5905-5^MON%^LN||6.0|%|3.0-12.0|~N|||F
+OBX|11|NM|713-8^EOS%^LN||2.5|%|0.5-5.0|~N|||F
+OBX|12|NM|706-2^BAS%^LN||0.5|%|0.0-1.0|~N|||F
+OBX|13|NM|751-8^NEU#^LN||3.96|10*3/uL|2.00-7.00|~N|||F
+OBX|14|NM|731-0^LYM#^LN||2.59|10*3/uL|0.80-4.00|~N|||F
+OBX|15|NM|742-7^MON#^LN||0.43|10*3/uL|0.12-1.20|~N|||F
+OBX|16|NM|711-2^EOS#^LN||0.18|10*3/uL|0.02-0.50|~N|||F
+OBX|17|NM|704-7^BAS#^LN||0.04|10*3/uL|0.00-0.10|~N|||F
+OBX|18|NM|26477-0^*ALY#^LN||0.05|10*3/uL|0.00-0.20|~N|||F
+OBX|19|NM|13046-8^*ALY%^LN||0.7|%|0.0-2.0|~N|||F
+OBX|20|NM|11001^*LIC#^99MRC||0.00|10*3/uL|0.00-0.20|~N|||F
+OBX|21|NM|11002^*LIC%^99MRC||0.0|%|0.0-2.5|~N|||F
+OBX|22|NM|789-8^RBC^LN||4.20|10*6/uL|3.50-5.50|~N|||F
+OBX|23|NM|718-7^HGB^LN||12.8|g/dL|11.0-16.0|~N|||F
+OBX|24|NM|4544-3^HCT^LN||38.5|%|37.0-54.0|~N|||F
+OBX|25|NM|787-2^MCV^LN||91.7|fL|80.0-100.0|~N|||F
+OBX|26|NM|785-6^MCH^LN||30.5|pg|27.0-34.0|~N|||F
+OBX|27|NM|786-4^MCHC^LN||33.2|g/dL|32.0-36.0|~N|||F
+OBX|28|NM|788-0^RDW-CV^LN||13.5|%|11.0-16.0|~N|||F
+OBX|29|NM|21000-5^RDW-SD^LN||44.0|fL|35.0-56.0|~N|||F
+OBX|30|NM|11092^*Mentzr^LN||21.83|||~N|||F
+OBX|31|NM|11093^*RDWI^LN||295.00|||~N|||F
+OBX|32|NM|777-3^PLT^LN||250|10*3/uL|100-300|~N|||F
+OBX|33|NM|32623-1^MPV^LN||9.2|fL|6.5-12.0|~N|||F
+OBX|34|NM|32207-3^PDW-SD^LN||11.0|fL|9.0-17.0|~N|||F
+OBX|35|NM|11090^PDW-CV^LN||14.5|%|10.0-17.9|~N|||F
+OBX|36|NM|11003^PCT^99MRC||0.230|%|0.108-0.282|~N|||F
+OBX|37|NM|48386-7^P-LCR^LN||22.0|%|11.0-45.0|~N|||F
+OBX|38|NM|34167-7^P-LCC^LN||55|10*9/L|30-90|~N|||F
+```
+
+**Notes:**
+- MSH-3: `ELite 580`
+- Test mode: `CBC+DIFF` - full 5-part differential
+- Includes ALY#/ALY% and LIC#/LIC% - ELite 580 extended parameters
+- Mentzer and RDWI present (observed in real ELite 580 messages)
+- PDW sent as PDW-SD + PDW-CV (observed in real messages despite brochure
+  listing PDW as a single parameter)

--- a/analyzers/ErbaHematology/README.md
+++ b/analyzers/ErbaHematology/README.md
@@ -1,0 +1,166 @@
+# Erba Hematology Plugin
+
+Plugin for **Erba Mannheim hematology analyzers** (H360, H560, Elite 580).
+
+---
+
+## Identification
+
+Messages are identified based on HL7 MSH segment fields:
+
+- **MSH-4 (Sending Facility):** `Erba`
+- **MSH-3 (Sending Application):** `H360`, `H560`, or `ELite 580`
+
+---
+
+## Protocol
+
+| Property     | Value              |
+|--------------|--------------------|
+| Protocol     | HL7 v2.3.1         |
+| Transport    | TCP/IP (MLLP)      |
+| Category     | Hematology         |
+| Manufacturer | Erba Mannheim      |
+
+---
+
+## Test Mappings
+
+### WBC
+
+| Analyzer Code | OBX-3 ID | Test Name             | LOINC   | Encoding | Models          |
+|---------------|----------|-----------------------|---------|----------|-----------------|
+| WBC           | 6690-2   | White Blood Cells     | 6690-2  | LN       | All             |
+
+### WBC Differential — 5-part % (CBC+DIFF mode)
+
+| Analyzer Code | OBX-3 ID | Test Name          | LOINC  | Encoding | Models     |
+|---------------|----------|--------------------|--------|----------|------------|
+| NEU%          | 770-8    | Neutrophils %      | 770-8  | LN       | ELITE 580  |
+| LYM%          | 736-9    | Lymphocytes %      | 736-9  | LN       | ELITE 580  |
+| MON%          | 5905-5   | Monocytes %        | 5905-5 | LN       | ELITE 580  |
+| EOS%          | 713-8    | Eosinophils %      | 713-8  | LN       | ELITE 580  |
+| BAS%          | 706-2    | Basophils %        | 706-2  | LN       | ELITE 580  |
+
+### WBC Differential — 5-part # (CBC+DIFF mode)
+
+| Analyzer Code | OBX-3 ID | Test Name             | LOINC  | Encoding | Models     |
+|---------------|----------|-----------------------|--------|----------|------------|
+| NEU#          | 751-8    | Neutrophils Absolute  | 751-8  | LN       | ELITE 580  |
+| LYM#          | 731-0    | Lymphocytes Absolute  | 731-0  | LN       | ELITE 580  |
+| MON#          | 742-7    | Monocytes Absolute    | 742-7  | LN       | ELITE 580  |
+| EOS#          | 711-2    | Eosinophils Absolute  | 711-2  | LN       | ELITE 580  |
+| BAS#          | 704-7    | Basophils Absolute    | 704-7  | LN       | ELITE 580  |
+
+### WBC Differential — 3-part (CBC+3DIFF mode)
+
+GRAN = granulocytes (NEU + EOS + BAS combined); MID = mid-range cells (MON + atypical lymphocytes combined).
+
+| Analyzer Code | OBX-3 ID | Test Name                  | LOINC   | Encoding | Models |
+|---------------|----------|----------------------------|---------|----------|--------|
+| GRAN%         | 20482-6  | Granulocytes %             | 20482-6 | LN       | H360   |
+| MID%          | 32155-4  | Mid-range Cells %          | 32155-4 | LN       | H360   |
+| GRAN#         | 19023-1  | Granulocytes Absolute      | 19023-1 | LN       | H360   |
+| MID#          | 32154-7  | Mid-range Cells Absolute   | 32154-7 | LN       | H360   |
+
+### RBC Series
+
+| Analyzer Code | OBX-3 ID | Test Name                                 | LOINC   | Encoding | Models |
+|---------------|----------|-------------------------------------------|---------|----------|--------|
+| RBC           | 789-8    | Red Blood Cells                           | 789-8   | LN       | All    |
+| HGB           | 718-7    | Hemoglobin                                | 718-7   | LN       | All    |
+| HCT           | 4544-3   | Hematocrit                                | 4544-3  | LN       | All    |
+| MCV           | 787-2    | Mean Corpuscular Volume                   | 787-2   | LN       | All    |
+| MCH           | 785-6    | Mean Corpuscular Hemoglobin               | 785-6   | LN       | All    |
+| MCHC          | 786-4    | Mean Corpuscular Hemoglobin Concentration | 786-4   | LN       | All    |
+| RDW-CV        | 788-0    | RDW-CV                                    | 788-0   | LN       | All    |
+| RDW-SD        | 21000-5  | RDW-SD                                    | 21000-5 | LN       | All    |
+
+### RBC Derived Indices
+
+| Analyzer Code | OBX-3 ID | Test Name          | LOINC | Encoding | Models |
+|---------------|----------|--------------------|-------|----------|--------|
+| *Mentzr       | 11092    | Mentzer Index      | 11092 | 99MRC    | All    |
+| *RDWI         | 11093    | RDW Index          | 11093 | 99MRC    | All    |
+
+### Platelet Series
+
+| Analyzer Code | OBX-3 ID | Test Name                       | LOINC   | Encoding | Models |
+|---------------|----------|---------------------------------|---------|----------|--------|
+| PLT           | 777-3    | Platelets                       | 777-3   | LN       | All    |
+| MPV           | 32623-1  | Mean Platelet Volume            | 32623-1 | LN       | All    |
+| PDW           | 32207-3  | Platelet Distribution Width     | 32207-3 | LN       | All    |
+| PDW-SD        | 32207-3  | Platelet Distribution Width SD  | 32207-3 | LN       | All    |
+| PDW-CV        | 11090    | Platelet Distribution Width CV  | 11090   | 99MRC    | All    |
+| PCT           | 11003    | Plateletcrit                    | 11003   | 99MRC    | All    |
+| P-LCR         | 48386-7  | Platelet Large Cell Ratio       | 48386-7 | LN       | All    |
+| P-LCC         | 34167-7  | Platelet Large Cell Count       | 34167-7 | LN       | All    |
+
+### Extended Parameters — Atypical / Large Immature Cells
+
+| Analyzer Code | OBX-3 ID | Test Name                       | LOINC   | Encoding | Models     |
+|---------------|----------|---------------------------------|---------|----------|------------|
+| *ALY#         | 26477-0  | Atypical Lymphocytes Absolute   | 26477-0 | LN       | ELITE 580  |
+| *ALY%         | 13046-8  | Atypical Lymphocytes %          | 13046-8 | LN       | ELITE 580  |
+| *LIC#         | 11001    | Large Immature Cells Absolute   | 11001   | 99MRC    | ELITE 580  |
+| *LIC%         | 11002    | Large Immature Cells %          | 11002   | 99MRC    | ELITE 580  |
+
+### Silently Ignored Segments
+
+These OBX segments are transmitted by the instrument but carry no clinical result
+value and are not stored in OpenELIS. They route to `notMatchedResults` harmlessly.
+
+| OBX-3 ID | Name                     | Type |
+|----------|--------------------------|------|
+| 02001    | Take Mode                | IS   |
+| 02002    | Blood Mode               | IS   |
+| 02003    | Test Mode                | IS   |
+| 03001    | Reference Group          | IS   |
+| 09001    | Remark                   | IS   |
+| 30525-0  | Age                      | NM   |
+| 13xxx    | Alarm / flag codes       | IS   |
+| ED type  | Histograms / scattergrams| ED   |
+
+---
+
+## Message Format
+
+- **Format**: HL7 v2.3.1
+- **Transport Framing**: MLLP
+  - Start Block: `<VT>` (`0x0B`)
+  - End Block: `<FS>` (`0x1C`)
+  - Segment Terminator: `<CR>` (`0x0D`)
+- **Encoding**: UTF-8 (`MSH-18 = UNICODE`)
+- **Accession / Sample ID**: `OBR-3` (Filler Order Number)
+- **QC detection**: `OBR-13` (Relevant Clinical Info) non-empty → flagged as control
+- **Results**: `OBX` segments
+  - Test Code: `OBX-3` (ID component, format `ID^Name^EncodeSys`)
+  - Value Type: `OBX-2` (`NM`, `IS`, `ST`; `ED` segments are skipped)
+  - Value: `OBX-5`
+  - Units: `OBX-6`
+  - Abnormal Flag: `OBX-8` (e.g. `H~A` = High + Abnormal)
+
+### Model Differences
+
+| Feature           | H360                   | H560                          | ELite 580                     |
+|-------------------|------------------------|-------------------------------|-------------------------------|
+| Differential      | 3-part                 | 5-part                        | 5-part + extended params.     |
+| Reportable params | ~22                    | ~26 (varies)                  | ~26+ (varies)                 |
+| WBC diff          | GRAN/MID/LYM (% and #) | NEU/LYM/MON/EOS/BAS (% and #) | NEU/LYM/MON/EOS/BAS (% and #) |
+
+---
+
+## Build
+
+```bash
+cd plugins/analyzers/ErbaHematology
+mvn clean package
+```
+
+## Installation
+
+Copy the built JAR to `/var/lib/openelis-global/plugins/` and restart OpenELIS.
+
+---
+
+**Last Verified:** 2026-03-22

--- a/analyzers/ErbaHematology/pom.xml
+++ b/analyzers/ErbaHematology/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openelisglobal</groupId>
+    <artifactId>openelisglobal-plugins</artifactId>
+    <version>1.0</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>ErbaHematology</artifactId>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <hapi.version>2.5.1</hapi.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>ca.uhn.hapi</groupId>
+      <artifactId>hapi-hl7overhttp</artifactId>
+      <version>${hapi.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ca.uhn.hapi</groupId>
+      <artifactId>hapi-structures-v231</artifactId>
+      <version>${hapi.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+      <version>${springframework.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openelisglobal.plugins</groupId>
+      <artifactId>test-utilities</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <filtering>true</filtering>
+        <directory>src/main/filtered-resources</directory>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <outputDirectory>${project.basedir}/../../plugins</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>target/</directory>
+                  <includes>
+                    <include>${project.build.finalName}.jar</include>
+                  </includes>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/analyzers/ErbaHematology/src/main/java/org/openelisglobal/plugins/analyzer/ErbaHematology/ErbaHematologyAnalyzer.java
+++ b/analyzers/ErbaHematology/src/main/java/org/openelisglobal/plugins/analyzer/ErbaHematology/ErbaHematologyAnalyzer.java
@@ -1,0 +1,238 @@
+package org.openelisglobal.plugins.analyzer.ErbaHematology;
+
+import static org.openelisglobal.common.services.PluginAnalyzerService.getInstance;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.openelisglobal.analyzerimport.analyzerreaders.AnalyzerLineInserter;
+import org.openelisglobal.common.services.PluginAnalyzerService;
+import org.openelisglobal.plugin.AnalyzerImporterPlugin;
+
+/**
+ * Plugin registration for ERBA MANNHEIM Hematology Analyzers (H360, H560, ELITE 580).
+ *
+ * <p>Test parameter codes and LOINC codes are sourced from the instrument's LIS Communication
+ * Protocol document, Appendix II (Table 9).
+ */
+public class ErbaHematologyAnalyzer implements AnalyzerImporterPlugin {
+
+  @Override
+  public boolean connect() {
+    List<PluginAnalyzerService.TestMapping> nameMapping = new ArrayList<>();
+
+    //  WBC total
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.WBC,
+            "White Blood Cells",
+            ErbaHematologyAnalyzerLineInserter.WBC_LOINC));
+
+    //  5-part differential % (ELITE 580 CBC+DIFF mode)
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.NEU_PCT,
+            "Neutrophils %",
+            ErbaHematologyAnalyzerLineInserter.NEU_PCT_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.LYM_PCT,
+            "Lymphocytes %",
+            ErbaHematologyAnalyzerLineInserter.LYM_PCT_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.MON_PCT,
+            "Monocytes %",
+            ErbaHematologyAnalyzerLineInserter.MON_PCT_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.EOS_PCT,
+            "Eosinophils %",
+            ErbaHematologyAnalyzerLineInserter.EOS_PCT_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.BAS_PCT,
+            "Basophils %",
+            ErbaHematologyAnalyzerLineInserter.BAS_PCT_LOINC));
+
+    //  5-part differential # (ELITE 580 CBC+DIFF mode)
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.NEU_ABS,
+            "Neutrophils Absolute",
+            ErbaHematologyAnalyzerLineInserter.NEU_ABS_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.LYM_ABS,
+            "Lymphocytes Absolute",
+            ErbaHematologyAnalyzerLineInserter.LYM_ABS_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.MON_ABS,
+            "Monocytes Absolute",
+            ErbaHematologyAnalyzerLineInserter.MON_ABS_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.EOS_ABS,
+            "Eosinophils Absolute",
+            ErbaHematologyAnalyzerLineInserter.EOS_ABS_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.BAS_ABS,
+            "Basophils Absolute",
+            ErbaHematologyAnalyzerLineInserter.BAS_ABS_LOINC));
+
+    //  3-part differential (H360 CBC+3DIFF mode)
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.GRAN_PCT,
+            "Granulocytes %",
+            ErbaHematologyAnalyzerLineInserter.GRAN_PCT_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.MID_PCT,
+            "Mid-range Cells %",
+            ErbaHematologyAnalyzerLineInserter.MID_PCT_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.GRAN_ABS,
+            "Granulocytes Absolute",
+            ErbaHematologyAnalyzerLineInserter.GRAN_ABS_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.MID_ABS,
+            "Mid-range Cells Absolute",
+            ErbaHematologyAnalyzerLineInserter.MID_ABS_LOINC));
+
+    //  RBC series
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.RBC,
+            "Red Blood Cells",
+            ErbaHematologyAnalyzerLineInserter.RBC_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.HGB,
+            "Hemoglobin",
+            ErbaHematologyAnalyzerLineInserter.HGB_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.HCT,
+            "Hematocrit",
+            ErbaHematologyAnalyzerLineInserter.HCT_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.MCV,
+            "Mean Corpuscular Volume",
+            ErbaHematologyAnalyzerLineInserter.MCV_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.MCH,
+            "Mean Corpuscular Hemoglobin",
+            ErbaHematologyAnalyzerLineInserter.MCH_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.MCHC,
+            "Mean Corpuscular Hemoglobin Concentration",
+            ErbaHematologyAnalyzerLineInserter.MCHC_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.RDW_CV,
+            "RDW-CV",
+            ErbaHematologyAnalyzerLineInserter.RDW_CV_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.RDW_SD,
+            "RDW-SD",
+            ErbaHematologyAnalyzerLineInserter.RDW_SD_LOINC));
+
+    //  RBC indices (Mentzer, RDWI)
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.MENTZER,
+            "Mentzer Index",
+            ErbaHematologyAnalyzerLineInserter.MENTZER_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.RDWI,
+            "RDW Index",
+            ErbaHematologyAnalyzerLineInserter.RDWI_LOINC));
+
+    //  Platelet series
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.PLT,
+            "Platelets",
+            ErbaHematologyAnalyzerLineInserter.PLT_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.MPV,
+            "Mean Platelet Volume",
+            ErbaHematologyAnalyzerLineInserter.MPV_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.PDW,
+            "Platelet Distribution Width",
+            ErbaHematologyAnalyzerLineInserter.PDW_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.PDW_SD,
+            "Platelet Distribution Width SD",
+            ErbaHematologyAnalyzerLineInserter.PDW_SD_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.PDW_CV,
+            "Platelet Distribution Width CV",
+            ErbaHematologyAnalyzerLineInserter.PDW_CV_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.PCT,
+            "Plateletcrit",
+            ErbaHematologyAnalyzerLineInserter.PCT_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.PLCR,
+            "Platelet Large Cell Ratio",
+            ErbaHematologyAnalyzerLineInserter.PLCR_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.PLCC,
+            "Platelet Large Cell Count",
+            ErbaHematologyAnalyzerLineInserter.PLCC_LOINC));
+
+    //  Atypical / large immature cells (ELITE 580 only)
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.ALY_ABS,
+            "Atypical Lymphocytes Absolute",
+            ErbaHematologyAnalyzerLineInserter.ALY_ABS_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.ALY_PCT,
+            "Atypical Lymphocytes %",
+            ErbaHematologyAnalyzerLineInserter.ALY_PCT_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.LIC_ABS,
+            "Large Immature Cells Absolute",
+            ErbaHematologyAnalyzerLineInserter.LIC_ABS_LOINC));
+    nameMapping.add(
+        new PluginAnalyzerService.TestMapping(
+            ErbaHematologyAnalyzerLineInserter.LIC_PCT,
+            "Large Immature Cells %",
+            ErbaHematologyAnalyzerLineInserter.LIC_PCT_LOINC));
+
+    getInstance().addAnalyzerDatabaseParts("ErbaHematology", "ErbaHematology", nameMapping, true);
+    getInstance().registerAnalyzer(this);
+    return true;
+  }
+
+  @Override
+  public boolean isTargetAnalyzer(List<String> lines) {
+    return false;
+  }
+
+  @Override
+  public AnalyzerLineInserter getAnalyzerLineInserter() {
+    return new ErbaHematologyAnalyzerLineInserter();
+  }
+}

--- a/analyzers/ErbaHematology/src/main/java/org/openelisglobal/plugins/analyzer/ErbaHematology/ErbaHematologyAnalyzerLineInserter.java
+++ b/analyzers/ErbaHematology/src/main/java/org/openelisglobal/plugins/analyzer/ErbaHematology/ErbaHematologyAnalyzerLineInserter.java
@@ -1,0 +1,294 @@
+package org.openelisglobal.plugins.analyzer.ErbaHematology;
+
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import org.openelisglobal.analyzerimport.analyzerreaders.AnalyzerLineInserter;
+import org.openelisglobal.analyzerimport.analyzerreaders.AnalyzerReaderUtil;
+import org.openelisglobal.analyzerresults.valueholder.AnalyzerResults;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.spring.util.SpringContext;
+import org.openelisglobal.test.service.TestService;
+import org.openelisglobal.test.valueholder.Test;
+
+/**
+ * Result persistence implementation for ERBA MANNHEIM Hematology Analyzers (H360, H560, ELITE 580).
+ *
+ * <p>Constants are derived from two sources:
+ *
+ * <ol>
+ *   <li>The instrument's LIS Communication Protocol, Appendix II Table 9.
+ *   <li>Real HL7 messages captured from H360, H560, and ELITE 580 instruments, which revealed
+ *       additional parameters (GRAN, MID, PDW-CV, Mentzer, RDWI, LIC) not present in the protocol
+ *       document's example messages.
+ * </ol>
+ *
+ * <p>The analyzerTestId passed to {@link #addResult} is the ID component of OBX-3 (format {@code
+ * ID^Name^EncodeSys}), which is the LOINC code for LN parameters or the vendor code for 99MRC
+ * parameters. Both are used as keys into the testLoincMap uniformly.
+ *
+ * <p>Model-specific notes:
+ *
+ * <ul>
+ *   <li><b>H360</b>: sends CBC+3DIFF uses GRAN%/#, MID%/# instead of the full 5-part
+ *       NEU/MON/EOS/BAS split.
+ *   <li><b>H560</b>: sends CBC only no differential parameters.
+ *   <li><b>ELITE 580</b>: sends CBC+DIFF (5-part) full NEU/LYM/MON/EOS/BAS plus ALY and LIC
+ *       extended parameters.
+ *   <li>All three models send PDW as two separate parameters: PDW-SD and PDW-CV. There is no plain
+ *       "PDW" OBX segment in any real message.
+ * </ul>
+ */
+public class ErbaHematologyAnalyzerLineInserter extends AnalyzerLineInserter {
+
+  // =========================================================================
+  // OBX-3 ID component strings  (what the instrument sends in OBX-3)
+  // =========================================================================
+
+  //  WBC total
+  static final String WBC = "WBC";
+
+  //  5-part differential % (ELITE 580, CBC+DIFF mode)
+  static final String NEU_PCT = "NEU%";
+  static final String LYM_PCT = "LYM%";
+  static final String MON_PCT = "MON%";
+  static final String EOS_PCT = "EOS%";
+  static final String BAS_PCT = "BAS%";
+
+  //  5-part differential # (ELITE 580, CBC+DIFF mode)
+  static final String NEU_ABS = "NEU#";
+  static final String LYM_ABS = "LYM#";
+  static final String MON_ABS = "MON#";
+  static final String EOS_ABS = "EOS#";
+  static final String BAS_ABS = "BAS#";
+
+  //  3-part differential (H360, CBC+3DIFF mode)
+  static final String GRAN_PCT = "GRAN%";
+  static final String MID_PCT = "MID%";
+  static final String GRAN_ABS = "GRAN#";
+  static final String MID_ABS = "MID#";
+
+  //  RBC series (all models)
+  static final String RBC = "RBC";
+  static final String HGB = "HGB";
+  static final String HCT = "HCT";
+  static final String MCV = "MCV";
+  static final String MCH = "MCH";
+  static final String MCHC = "MCHC";
+  static final String RDW_CV = "RDW-CV";
+  static final String RDW_SD = "RDW-SD";
+
+  //  RBC derived indices (H360, ELITE 580)
+  static final String MENTZER = "*Mentzr";
+  static final String RDWI = "*RDWI";
+
+  //  Platelet series (all models)
+  static final String PLT = "PLT";
+  static final String MPV = "MPV";
+  static final String PDW = "PDW";
+  static final String PDW_SD = "PDW-SD";
+  static final String PDW_CV = "PDW-CV";
+  static final String PCT = "PCT";
+  static final String PLCR = "P-LCR";
+  static final String PLCC = "P-LCC";
+
+  //  Atypical / large immature cells (ELITE 580 only)
+  static final String ALY_ABS = "*ALY#";
+  static final String ALY_PCT = "*ALY%";
+  static final String LIC_ABS = "*LIC#";
+  static final String LIC_PCT = "*LIC%";
+
+  // LN = standard LOINC  |  99MRC = vendor-defined
+
+  static final String WBC_LOINC = "6690-2"; // LN
+  static final String NEU_PCT_LOINC = "770-8"; // LN
+  static final String LYM_PCT_LOINC = "736-9"; // LN
+  static final String MON_PCT_LOINC = "5905-5"; // LN
+  static final String EOS_PCT_LOINC = "713-8"; // LN
+  static final String BAS_PCT_LOINC = "706-2"; // LN
+  static final String NEU_ABS_LOINC = "751-8"; // LN
+  static final String LYM_ABS_LOINC = "731-0"; // LN
+  static final String MON_ABS_LOINC = "742-7"; // LN
+  static final String EOS_ABS_LOINC = "711-2"; // LN
+  static final String BAS_ABS_LOINC = "704-7"; // LN
+  static final String GRAN_PCT_LOINC = "20482-6"; // LN
+  static final String MID_PCT_LOINC = "32155-4"; // LN
+  static final String GRAN_ABS_LOINC = "19023-1"; // LN
+  static final String MID_ABS_LOINC = "32154-7"; // LN
+  static final String RBC_LOINC = "789-8"; // LN
+  static final String HGB_LOINC = "718-7"; // LN
+  static final String HCT_LOINC = "4544-3"; // LN
+  static final String MCV_LOINC = "787-2"; // LN
+  static final String MCH_LOINC = "785-6"; // LN
+  static final String MCHC_LOINC = "786-4"; // LN
+  static final String RDW_CV_LOINC = "788-0"; // LN
+  static final String RDW_SD_LOINC = "21000-5"; // LN
+  static final String MENTZER_LOINC = "11092"; // 99MRC
+  static final String RDWI_LOINC = "11093"; // 99MRC
+  static final String PLT_LOINC = "777-3"; // LN
+  static final String MPV_LOINC = "32623-1"; // LN
+  static final String PDW_LOINC = "32207-3"; // LN
+  static final String PDW_SD_LOINC = "32207-3"; // LN
+  static final String PDW_CV_LOINC = "11090"; // 99MRC
+  static final String PCT_LOINC = "11003"; // 99MRC
+  static final String PLCR_LOINC = "48386-7"; // LN
+  static final String PLCC_LOINC = "34167-7"; // LN
+  static final String ALY_ABS_LOINC = "26477-0"; // LN
+  static final String ALY_PCT_LOINC = "13046-8"; // LN
+  static final String LIC_ABS_LOINC = "11001"; // 99MRC
+  static final String LIC_PCT_LOINC = "11002"; // 99MRC
+
+  private TestService testService;
+  private HashMap<String, List<Test>> testLoincMap;
+  private final AnalyzerReaderUtil readerUtil = new AnalyzerReaderUtil();
+
+  protected TestService getTestService() {
+    if (testService == null) {
+      testService = SpringContext.getBean(TestService.class);
+    }
+    return testService;
+  }
+
+  protected HashMap<String, List<Test>> getTestLoincMap() {
+    if (testLoincMap == null) {
+      testLoincMap = new HashMap<>();
+      TestService ts = getTestService();
+
+      testLoincMap.put(WBC_LOINC, ts.getTestsByLoincCode(WBC_LOINC));
+      testLoincMap.put(NEU_PCT_LOINC, ts.getTestsByLoincCode(NEU_PCT_LOINC));
+      testLoincMap.put(LYM_PCT_LOINC, ts.getTestsByLoincCode(LYM_PCT_LOINC));
+      testLoincMap.put(MON_PCT_LOINC, ts.getTestsByLoincCode(MON_PCT_LOINC));
+      testLoincMap.put(EOS_PCT_LOINC, ts.getTestsByLoincCode(EOS_PCT_LOINC));
+      testLoincMap.put(BAS_PCT_LOINC, ts.getTestsByLoincCode(BAS_PCT_LOINC));
+      testLoincMap.put(NEU_ABS_LOINC, ts.getTestsByLoincCode(NEU_ABS_LOINC));
+      testLoincMap.put(LYM_ABS_LOINC, ts.getTestsByLoincCode(LYM_ABS_LOINC));
+      testLoincMap.put(MON_ABS_LOINC, ts.getTestsByLoincCode(MON_ABS_LOINC));
+      testLoincMap.put(EOS_ABS_LOINC, ts.getTestsByLoincCode(EOS_ABS_LOINC));
+      testLoincMap.put(BAS_ABS_LOINC, ts.getTestsByLoincCode(BAS_ABS_LOINC));
+      testLoincMap.put(GRAN_PCT_LOINC, ts.getTestsByLoincCode(GRAN_PCT_LOINC));
+      testLoincMap.put(MID_PCT_LOINC, ts.getTestsByLoincCode(MID_PCT_LOINC));
+      testLoincMap.put(GRAN_ABS_LOINC, ts.getTestsByLoincCode(GRAN_ABS_LOINC));
+      testLoincMap.put(MID_ABS_LOINC, ts.getTestsByLoincCode(MID_ABS_LOINC));
+      testLoincMap.put(RBC_LOINC, ts.getTestsByLoincCode(RBC_LOINC));
+      testLoincMap.put(HGB_LOINC, ts.getTestsByLoincCode(HGB_LOINC));
+      testLoincMap.put(HCT_LOINC, ts.getTestsByLoincCode(HCT_LOINC));
+      testLoincMap.put(MCV_LOINC, ts.getTestsByLoincCode(MCV_LOINC));
+      testLoincMap.put(MCH_LOINC, ts.getTestsByLoincCode(MCH_LOINC));
+      testLoincMap.put(MCHC_LOINC, ts.getTestsByLoincCode(MCHC_LOINC));
+      testLoincMap.put(RDW_CV_LOINC, ts.getTestsByLoincCode(RDW_CV_LOINC));
+      testLoincMap.put(RDW_SD_LOINC, ts.getTestsByLoincCode(RDW_SD_LOINC));
+      testLoincMap.put(MENTZER_LOINC, ts.getTestsByLoincCode(MENTZER_LOINC));
+      testLoincMap.put(RDWI_LOINC, ts.getTestsByLoincCode(RDWI_LOINC));
+      testLoincMap.put(PLT_LOINC, ts.getTestsByLoincCode(PLT_LOINC));
+      testLoincMap.put(MPV_LOINC, ts.getTestsByLoincCode(MPV_LOINC));
+      testLoincMap.put(PDW_LOINC, ts.getTestsByLoincCode(PDW_LOINC));
+      testLoincMap.put(PDW_SD_LOINC, ts.getTestsByLoincCode(PDW_SD_LOINC));
+      testLoincMap.put(PDW_CV_LOINC, ts.getTestsByLoincCode(PDW_CV_LOINC));
+      testLoincMap.put(PCT_LOINC, ts.getTestsByLoincCode(PCT_LOINC));
+      testLoincMap.put(PLCR_LOINC, ts.getTestsByLoincCode(PLCR_LOINC));
+      testLoincMap.put(PLCC_LOINC, ts.getTestsByLoincCode(PLCC_LOINC));
+      testLoincMap.put(ALY_ABS_LOINC, ts.getTestsByLoincCode(ALY_ABS_LOINC));
+      testLoincMap.put(ALY_PCT_LOINC, ts.getTestsByLoincCode(ALY_PCT_LOINC));
+      testLoincMap.put(LIC_ABS_LOINC, ts.getTestsByLoincCode(LIC_ABS_LOINC));
+      testLoincMap.put(LIC_PCT_LOINC, ts.getTestsByLoincCode(LIC_PCT_LOINC));
+
+      LogEvent.logDebug(
+          this.getClass().getSimpleName(),
+          "getTestLoincMap",
+          "ErbaHematology LOINC map initialised with " + testLoincMap.size() + " entries");
+    }
+    return testLoincMap;
+  }
+
+  @Override
+  public boolean insert(List<String> lines, String currentUserId) {
+    return false;
+  }
+
+  @Override
+  public String getError() {
+    return "ErbaHematology analyzer unable to write to database";
+  }
+
+  /**
+   * Creates an {@link AnalyzerResults} from a single OBX segment and routes it to {@code
+   * resultList} (matched) or {@code notMatchedResults} (unmatched).
+   *
+   * <p>IS-type metadata segments (Take Mode, Blood Mode, Test Mode, Ref Group, Remark codes 02001,
+   * 02002, 02003, 03001, 09001) and alarm flag segments (codes 13xxx) have no entry in the LOINC
+   * map and go quietly to {@code notMatchedResults}.
+   *
+   * @param resultList accumulates results with a matched OpenELIS test
+   * @param notMatchedResults accumulates results with no matching test
+   * @param resultType OBX-2 value type (NM, IS, ST …)
+   * @param resultValue OBX-5 observation value
+   * @param accessionNumber OBR-3 filler order number (sample ID)
+   * @param isControl true when OBR-13 is non-empty (QC sample)
+   * @param resultUnits OBX-6 unit string
+   * @param analyzerTestId OBX-3 ID component used as testLoincMap key
+   */
+  public void addResult(
+      List<AnalyzerResults> resultList,
+      List<AnalyzerResults> notMatchedResults,
+      String resultType,
+      String resultValue,
+      String accessionNumber,
+      boolean isControl,
+      String resultUnits,
+      String analyzerTestId) {
+
+    AnalyzerResults analyzerResults =
+        createAnalyzerResult(
+            resultType, resultValue, resultUnits, accessionNumber, isControl, analyzerTestId);
+
+    if (analyzerResults.getTestId() != null) {
+      addValueToResults(resultList, analyzerResults);
+    } else {
+      LogEvent.logDebug(
+          this.getClass().getSimpleName(),
+          "addResult",
+          "No test match for analyzerTestId: " + analyzerTestId);
+      notMatchedResults.add(analyzerResults);
+    }
+  }
+
+  private void addValueToResults(List<AnalyzerResults> resultList, AnalyzerResults result) {
+    resultList.add(result);
+    AnalyzerResults resultFromDB = readerUtil.createAnalyzerResultFromDB(result);
+    if (resultFromDB != null) {
+      resultList.add(resultFromDB);
+    }
+  }
+
+  private AnalyzerResults createAnalyzerResult(
+      String resultType,
+      String resultValue,
+      String resultUnits,
+      String accessionNumber,
+      boolean isControl,
+      String analyzerTestId) {
+
+    AnalyzerResults analyzerResults = new AnalyzerResults();
+    analyzerResults.setResult(resultValue);
+    analyzerResults.setUnits(resultUnits);
+    analyzerResults.setCompleteDate(new Timestamp(new Date().getTime()));
+    analyzerResults.setAccessionNumber(accessionNumber);
+    analyzerResults.setIsControl(isControl);
+
+    List<Test> tests = getTestLoincMap().get(analyzerTestId);
+    if (tests != null && !tests.isEmpty()) {
+      analyzerResults.setTestId(tests.get(0).getId());
+      analyzerResults.setTestName(tests.get(0).getLocalizedTestName().getLocalizedValue());
+    } else {
+      analyzerResults.setTestId(null);
+      analyzerResults.setTestName("");
+    }
+
+    return analyzerResults;
+  }
+
+  public void persistImport(List<AnalyzerResults> resultList) {
+    this.persistImport("1", resultList);
+  }
+}

--- a/analyzers/ErbaHematology/src/main/java/org/openelisglobal/plugins/analyzer/ErbaHematology/ErbaHematologyMenu.java
+++ b/analyzers/ErbaHematology/src/main/java/org/openelisglobal/plugins/analyzer/ErbaHematology/ErbaHematologyMenu.java
@@ -1,0 +1,48 @@
+package org.openelisglobal.plugins.analyzer.ErbaHematology;
+
+import java.util.Locale;
+import org.openelisglobal.common.services.PluginMenuService;
+import org.openelisglobal.common.services.PluginMenuService.KnownMenu;
+import org.openelisglobal.menu.valueholder.Menu;
+import org.openelisglobal.plugin.MenuPlugin;
+
+/**
+ * Registers the ERBA MANNHEIM Hematology analyzer entry in the OpenELIS Analyzer Results menu.
+ *
+ * <p>The {@code actionURL} uses the analyzer name registered in {@link
+ * ErbaHematologyAnalyzer#connect()} via {@code addAnalyzerDatabaseParts("ErbaHematology", …)}.
+ */
+public class ErbaHematologyMenu extends MenuPlugin {
+
+  @Override
+  protected void insertMenu() {
+    PluginMenuService service = PluginMenuService.getInstance();
+
+    Menu menu = new Menu();
+    menu.setParent(service.getKnownMenu(KnownMenu.ANALYZER, "menu_results"));
+
+    // menu.setPresentationOrder(11);
+
+    menu.setElementId("erba_hematology_analyzer_plugin");
+
+    // Must match the analyzer name passed to addAnalyzerDatabaseParts()
+    menu.setActionURL("/AnalyzerResults?type=ErbaHematology");
+
+    // i18n key - must not already exist in MessageResource.properties
+    menu.setDisplayKey("banner.menu.results.erbahematologyanalyzer");
+    menu.setOpenInNewWindow(false);
+    service.addMenu(menu);
+
+    // English label
+    service.insertLanguageKeyValue(
+        "banner.menu.results.erbahematologyanalyzer",
+        "Erba Hematology",
+        Locale.ENGLISH.toLanguageTag());
+
+    // French label
+    service.insertLanguageKeyValue(
+        "banner.menu.results.erbahematologyanalyzer",
+        "Erba Hématologie",
+        Locale.FRENCH.toLanguageTag());
+  }
+}

--- a/analyzers/ErbaHematology/src/main/java/org/openelisglobal/plugins/analyzer/ErbaHematology/ErbaHematologyPermission.java
+++ b/analyzers/ErbaHematology/src/main/java/org/openelisglobal/plugins/analyzer/ErbaHematology/ErbaHematologyPermission.java
@@ -1,0 +1,29 @@
+package org.openelisglobal.plugins.analyzer.ErbaHematology;
+
+import org.openelisglobal.common.services.IPluginPermissionService;
+import org.openelisglobal.plugin.PermissionPlugin;
+import org.openelisglobal.role.valueholder.Role;
+import org.openelisglobal.spring.util.SpringContext;
+import org.openelisglobal.systemmodule.valueholder.SystemModule;
+
+/**
+ * Binds the "Results" role to the ErbaHematology analyzer module so that users with that role can
+ * access the Analyzer Results page for this instrument.
+ *
+ * <p>The module path string ({@code "Results->Analyzer->ErbaHematology"}) must match the analyzer
+ * name registered in {@link ErbaHematologyAnalyzer}.
+ */
+public class ErbaHematologyPermission extends PermissionPlugin {
+
+  @Override
+  protected boolean insertPermission() {
+    IPluginPermissionService service = SpringContext.getBean(IPluginPermissionService.class);
+
+    SystemModule module =
+        service.getOrCreateSystemModule(
+            "AnalyzerResults", "ErbaHematology", "Results->Analyzer->ErbaHematology");
+
+    Role role = service.getSystemRole("Results");
+    return service.bindRoleToModule(role, module);
+  }
+}

--- a/analyzers/ErbaHematology/src/main/java/org/openelisglobal/plugins/analyzer/ErbaHematology/ErbaHematologyServlet.java
+++ b/analyzers/ErbaHematology/src/main/java/org/openelisglobal/plugins/analyzer/ErbaHematology/ErbaHematologyServlet.java
@@ -1,0 +1,219 @@
+package org.openelisglobal.plugins.analyzer.ErbaHematology;
+
+import ca.uhn.hl7v2.AcknowledgmentCode;
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.hoh.hapi.server.HohServlet;
+import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.model.v231.group.ORU_R01_OBXNTE;
+import ca.uhn.hl7v2.model.v231.group.ORU_R01_ORCOBRNTEOBXNTECTI;
+import ca.uhn.hl7v2.model.v231.group.ORU_R01_PIDPD1NK1NTEPV1PV2ORCOBRNTEOBXNTECTI;
+import ca.uhn.hl7v2.model.v231.message.ACK;
+import ca.uhn.hl7v2.model.v231.message.ORU_R01;
+import ca.uhn.hl7v2.model.v231.segment.MSA;
+import ca.uhn.hl7v2.model.v231.segment.MSH;
+import ca.uhn.hl7v2.model.v231.segment.NTE;
+import ca.uhn.hl7v2.model.v231.segment.OBR;
+import ca.uhn.hl7v2.model.v231.segment.OBX;
+import ca.uhn.hl7v2.model.v231.segment.ORC;
+import ca.uhn.hl7v2.model.v231.segment.PID;
+import ca.uhn.hl7v2.protocol.ReceivingApplication;
+import ca.uhn.hl7v2.protocol.ReceivingApplicationException;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.analyzerresults.valueholder.AnalyzerResults;
+import org.openelisglobal.plugin.ServletPlugin;
+import org.openelisglobal.sample.service.SampleService;
+import org.openelisglobal.spring.util.SpringContext;
+
+/**
+ * HL7 v2.3.1 servlet for ERBA MANNHEIM Hematology Analyzers (H360, H560, ELITE 580).
+ *
+ * <p>The instrument initiates a persistent TCP connection to the LIS server and transmits ORU^R01
+ * messages framed with MLLP ({@code <0x0B>…<0x1C><0x0D>}). This servlet is registered as the HAPI
+ * HoH receiving application and processes each inbound message synchronously, returning an ACK^R01
+ * acknowledgement.
+ *
+ * <p>Message structure per protocol section 3.1.2:
+ *
+ * <pre>
+ *   MSH message header (UTF-8, HL7 v2.3.1)
+ *   PID patient identification
+ *   PV1 patient visit / medical information
+ *   {
+ *      OBR observation request (sample / QC info)
+ *      OBX observation results (one per test parameter)
+ *   }
+ * </pre>
+ *
+ * <p>QC messages are distinguished by a non-empty OBR-13 (Relevant Clinical Info) field; when that
+ * field is populated the result is flagged as a control.
+ *
+ * <p>Binary histogram / scattergram OBX segments (value type ED, Base64-encoded BMP/PNG) are
+ * silently skipped. Only numeric (NM) and coded (IS/ST) results are forwarded to the inserter.
+ */
+@SuppressWarnings("serial")
+public class ErbaHematologyServlet extends HohServlet implements ServletPlugin {
+
+  private final SampleService sampleService = SpringContext.getBean(SampleService.class);
+  private final AnalysisService analysisService = SpringContext.getBean(AnalysisService.class);
+  private final ErbaHematologyAnalyzerLineInserter inserter =
+      new ErbaHematologyAnalyzerLineInserter();
+
+  // Servlet lifecycle
+
+  @Override
+  public void init(ServletConfig theConfig) throws ServletException {
+    setApplication(new ErbaHematologyApplication());
+  }
+
+  // Inner ReceivingApplication
+
+  /**
+   * Only ORU^R01 (test / QC result upload) is currently implemented; all other message types
+   * receive an AR (Application Reject) ACK.
+   */
+  private class ErbaHematologyApplication implements ReceivingApplication<Message> {
+
+    @SuppressWarnings("unused")
+    private final Map<String, Message> activeRequests = new HashMap<>();
+
+    @Override
+    public Message processMessage(Message message, @SuppressWarnings("rawtypes") Map theMetadata)
+        throws ReceivingApplicationException, HL7Exception {
+
+      MSH msh = (MSH) message.get("MSH");
+      String messageStructure = msh.getMessageType().getMessageStructure().getValueOrEmpty();
+
+      Message response;
+      try {
+        switch (messageStructure) {
+          case "ORU^R01":
+            // Instrument uploads test results or QC data
+            response = handleResultsUpload((ORU_R01) message, theMetadata);
+            break;
+          default:
+            response =
+                message.generateACK(
+                    AcknowledgmentCode.AR,
+                    new HL7Exception("Message type not configured: " + messageStructure));
+        }
+      } catch (IOException e) {
+        throw new ReceivingApplicationException(e);
+      }
+      return response;
+    }
+
+    // ORU^R01 processing
+
+    /**
+     * Iterates through every patient / order / observation group in the ORU message and forwards
+     * each numeric/coded OBX result to the inserter.
+     *
+     * <p>Protocol notes:
+     *
+     * <ul>
+     *   <li>OBR-3 (Filler Order Number) carries the sample ID for patient results; OBR-2 (Placer
+     *       Order Number) is used in bi-directional query responses.
+     *   <li>OBR-13 (Relevant Clinical Info) is non-empty for QC messages ({@code isControl =
+     *       true}).
+     *   <li>OBX-3 identifier format: {@code ID^Name^EncodeSys} the ID component is used as the
+     *       analyzerTestId key.
+     *   <li>Binary histogram/scattergram segments have OBX-2 = ED and are skipped.
+     * </ul>
+     */
+    private Message handleResultsUpload(
+        ORU_R01 message, @SuppressWarnings("rawtypes") Map theMetadata)
+        throws HL7Exception, IOException {
+
+      List<AnalyzerResults> resultList = new ArrayList<>();
+      List<AnalyzerResults> notMatchedResults = new ArrayList<>();
+
+      for (ORU_R01_PIDPD1NK1NTEPV1PV2ORCOBRNTEOBXNTECTI patientResult :
+          message.getPIDPD1NK1NTEPV1PV2ORCOBRNTEOBXNTECTIAll()) {
+
+        @SuppressWarnings("unused")
+        PID pid = patientResult.getPIDPD1NK1NTEPV1PV2().getPID();
+
+        for (ORU_R01_ORCOBRNTEOBXNTECTI orderObservation :
+            patientResult.getORCOBRNTEOBXNTECTIAll()) {
+
+          @SuppressWarnings("unused")
+          ORC orc = orderObservation.getORC();
+          OBR obr = orderObservation.getOBR();
+
+          // OBR-3 holds the sample/file ID for patient and QC results
+          String accessionNumber = obr.getFillerOrderNumber().getEntityIdentifier().getValue();
+
+          // Non-empty OBR-13 flags this as a QC control sample
+          boolean isControl = !obr.getRelevantClinicalInfo().isEmpty();
+
+          Optional<NTE> orderNTE =
+              orderObservation.getNTEReps() <= 0
+                  ? Optional.empty()
+                  : Optional.of(orderObservation.getNTE());
+
+          for (ORU_R01_OBXNTE observation : orderObservation.getOBXNTEAll()) {
+            OBX obx = observation.getOBX();
+
+            String valueType = obx.getValueType().getValue();
+
+            // Skip binary image segments (histograms, scattergrams)
+            if ("ED".equalsIgnoreCase(valueType)) {
+              continue;
+            }
+
+            // OBX-3: ID^Name^EncodeSys  use the ID component as the lookup key
+            String analyzerTestId = obx.getObservationIdentifier().getIdentifier().getValue();
+
+            String observationValue = obx.getObservationValue(0).getData().encode();
+
+            String resultUnits = obx.getUnits().getText().getValue();
+
+            inserter.addResult(
+                resultList,
+                notMatchedResults,
+                valueType,
+                observationValue,
+                accessionNumber,
+                isControl,
+                resultUnits,
+                analyzerTestId);
+          }
+        }
+      }
+
+      inserter.persistImport(resultList);
+
+      return buildSuccessACK(message);
+    }
+
+    // ACK builder
+
+    /**
+     * Builds an ACK^R01 acknowledgement with MSA-1 = AA (message accepted) per protocol section
+     * 3.3.1.
+     *
+     * <p>The MSA-2 value is set to the MSH-10 message control ID of the received message so the
+     * instrument can correlate the ACK.
+     */
+    private ACK buildSuccessACK(ORU_R01 message) throws HL7Exception, IOException {
+      ACK response = (ACK) message.generateACK(AcknowledgmentCode.AA, null);
+      MSA msa = response.getMSA();
+      msa.getTextMessage().setValue("Message accepted");
+      msa.getErrorCondition().getIdentifier().setValue("0");
+      return response;
+    }
+
+    @Override
+    public boolean canProcess(Message theMessage) {
+      return true;
+    }
+  }
+}

--- a/analyzers/ErbaHematology/src/main/resources/ErbaHematology.xml
+++ b/analyzers/ErbaHematology/src/main/resources/ErbaHematology.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openElisGlobalPlugin>
+  <version>1.0</version>
+
+  <analyzerImporter>
+    <extension_point path="org.openelisglobal.plugin.AnalyzerImporterPlugin">
+      <extension path="org.openelisglobal.plugins.analyzer.ErbaHematology.ErbaHematologyAnalyzer"/>
+      <description value="ErbaHematology"/>
+    </extension_point>
+  </analyzerImporter>
+
+  <menu>
+    <extension_point path="org.openelisglobal.plugin.MenuPlugin">
+      <extension path="org.openelisglobal.plugins.analyzer.ErbaHematology.ErbaHematologyMenu"/>
+      <description value="Menu for ErbaHematology"/>
+    </extension_point>
+  </menu>
+
+  <permission>
+    <extension_point path="org.openelisglobal.plugin.PermissionPlugin">
+      <extension path="org.openelisglobal.plugins.analyzer.ErbaHematology.ErbaHematologyPermission"/>
+      <description value="ErbaHematology Analyzer permission"/>
+    </extension_point>
+  </permission>
+
+  <servlet>
+    <extension_point path="org.openelisglobal.plugin.ServletPlugin">
+      <extension path="org.openelisglobal.plugins.analyzer.ErbaHematology.ErbaHematologyServlet"/>
+      <servlet-path value="/ErbaHematologyServlet"/>
+      <servlet-name value="ErbaHematologyServlet"/>
+      <description value="ErbaHematology Analyzer servlet"/>
+    </extension_point>
+  </servlet>
+
+</openElisGlobalPlugin>

--- a/analyzers/ErbaHematology/src/test/java/org/openelisglobal/plugins/analyzer/ErbaHematology/ErbaHematologyAnalyzerImplementationTest.java
+++ b/analyzers/ErbaHematology/src/test/java/org/openelisglobal/plugins/analyzer/ErbaHematology/ErbaHematologyAnalyzerImplementationTest.java
@@ -1,0 +1,304 @@
+package org.openelisglobal.plugins.analyzer.ErbaHematology;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.openelisglobal.analyzerresults.valueholder.AnalyzerResults;
+import org.openelisglobal.plugin.test.PluginTestBase;
+import org.openelisglobal.test.service.TestService;
+
+/**
+ * Tests for {@link ErbaHematologyAnalyzerLineInserter}.
+ *
+ * <p>Because the implementation uses lazy initialization, no Spring context is required at
+ * construction time. Tests inject a mock {@link TestService} via the protected {@link
+ * ErbaHematologyAnalyzerLineInserter#getTestService()} override, avoiding the need to bootstrap the
+ * full application context.
+ */
+public class ErbaHematologyAnalyzerImplementationTest extends PluginTestBase {
+
+  /**
+   * Creates an implementation instance with a mock TestService injected. The mock returns an empty
+   * list for every LOINC lookup by default, simulating "test not configured in this OpenELIS
+   * instance".
+   */
+  private ErbaHematologyAnalyzerLineInserter instanceWithMock() {
+    TestService mockTestService = mock(TestService.class);
+    when(mockTestService.getTestsByLoincCode(anyString())).thenReturn(new ArrayList<>());
+
+    return new ErbaHematologyAnalyzerLineInserter() {
+      @Override
+      protected TestService getTestService() {
+        return mockTestService;
+      }
+    };
+  }
+
+  // Construction
+
+  @Test
+  public void testConstructor_DoesNotRequireSpringContext() {
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    assertNotNull(impl);
+  }
+
+  // Contract methods
+
+  @Test
+  public void testGetError_ReturnsExpectedMessage() {
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    assertEquals("ErbaHematology analyzer unable to write to database", impl.getError());
+  }
+
+  @Test
+  public void testInsert_AlwaysReturnsFalse() {
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    // Flat-file path is disabled; results arrive via the HL7 servlet only.
+    assertEquals(false, impl.insert(new ArrayList<>(), "user1"));
+  }
+
+  // addResult routing
+
+  @Test
+  public void testAddResult_UnknownLoincCode_RoutesToNotMatched() {
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    List<AnalyzerResults> matched = new ArrayList<>();
+    List<AnalyzerResults> unmatched = new ArrayList<>();
+
+    impl.addResult(matched, unmatched, "NM", "5.5", "ACC001", false, "10*3/uL", "UNKNOWN");
+
+    assertEquals(0, matched.size());
+    assertEquals(1, unmatched.size());
+  }
+
+  @Test
+  public void testAddResult_NullLoincCode_RoutesToNotMatched() {
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    List<AnalyzerResults> matched = new ArrayList<>();
+    List<AnalyzerResults> unmatched = new ArrayList<>();
+
+    impl.addResult(matched, unmatched, "NM", "5.5", "ACC002", false, "10*3/uL", null);
+
+    assertEquals(0, matched.size());
+    assertEquals(1, unmatched.size());
+  }
+
+  @Test
+  public void testAddResult_KnownLoincCode_MockReturnsEmpty_RoutesToNotMatched() {
+    // Even a known LOINC code routes to notMatched when the DB has no test
+    // configured for it (mock returns empty list).
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    List<AnalyzerResults> matched = new ArrayList<>();
+    List<AnalyzerResults> unmatched = new ArrayList<>();
+
+    impl.addResult(
+        matched,
+        unmatched,
+        "NM",
+        "8.67",
+        "ACC003",
+        false,
+        "10*3/uL",
+        ErbaHematologyAnalyzerLineInserter.WBC_LOINC);
+
+    assertEquals(0, matched.size());
+    assertEquals(1, unmatched.size());
+  }
+
+  // AnalyzerResults field values
+
+  @Test
+  public void testAddResult_ResultValueStoredCorrectly() {
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    List<AnalyzerResults> matched = new ArrayList<>();
+    List<AnalyzerResults> unmatched = new ArrayList<>();
+
+    impl.addResult(
+        matched,
+        unmatched,
+        "NM",
+        "12.0",
+        "ACC004",
+        false,
+        "g/dL",
+        ErbaHematologyAnalyzerLineInserter.HGB_LOINC);
+
+    AnalyzerResults result = unmatched.get(0);
+    assertEquals("12.0", result.getResult());
+    assertEquals("g/dL", result.getUnits());
+    assertEquals("ACC004", result.getAccessionNumber());
+    assertNull(result.getTestId());
+  }
+
+  @Test
+  public void testAddResult_ControlFlag_PropagatedCorrectly() {
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    List<AnalyzerResults> matched = new ArrayList<>();
+    List<AnalyzerResults> unmatched = new ArrayList<>();
+
+    // isControl = true simulates a QC message (OBR-13 non-empty per protocol)
+    impl.addResult(
+        matched,
+        unmatched,
+        "NM",
+        "5.51",
+        "QC-BATCH-01",
+        true,
+        "10*3/uL",
+        ErbaHematologyAnalyzerLineInserter.WBC_LOINC);
+
+    assertTrue(unmatched.get(0).getIsControl());
+  }
+
+  @Test
+  public void testAddResult_CompleteDate_IsSet() {
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    List<AnalyzerResults> matched = new ArrayList<>();
+    List<AnalyzerResults> unmatched = new ArrayList<>();
+
+    impl.addResult(
+        matched,
+        unmatched,
+        "NM",
+        "181",
+        "ACC005",
+        false,
+        "10*3/uL",
+        ErbaHematologyAnalyzerLineInserter.PLT_LOINC);
+
+    assertNotNull(unmatched.get(0).getCompleteDate());
+  }
+
+  // Model-specific parameters
+
+  @Test
+  public void testAddResult_H360_GranPct_Handled() {
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    List<AnalyzerResults> matched = new ArrayList<>();
+    List<AnalyzerResults> unmatched = new ArrayList<>();
+
+    impl.addResult(
+        matched,
+        unmatched,
+        "NM",
+        "74.8",
+        "ACC006",
+        false,
+        "%",
+        ErbaHematologyAnalyzerLineInserter.GRAN_PCT_LOINC);
+
+    assertEquals(1, unmatched.size());
+    assertEquals("74.8", unmatched.get(0).getResult());
+  }
+
+  @Test
+  public void testAddResult_H360_MidAbs_Handled() {
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    List<AnalyzerResults> matched = new ArrayList<>();
+    List<AnalyzerResults> unmatched = new ArrayList<>();
+
+    impl.addResult(
+        matched,
+        unmatched,
+        "NM",
+        "0.37",
+        "ACC007",
+        false,
+        "10*3/uL",
+        ErbaHematologyAnalyzerLineInserter.MID_ABS_LOINC);
+
+    assertEquals(1, unmatched.size());
+  }
+
+  @Test
+  public void testAddResult_Elite580_LicAbs_Handled() {
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    List<AnalyzerResults> matched = new ArrayList<>();
+    List<AnalyzerResults> unmatched = new ArrayList<>();
+
+    impl.addResult(
+        matched,
+        unmatched,
+        "NM",
+        "0.00",
+        "ACC008",
+        false,
+        "10*3/uL",
+        ErbaHematologyAnalyzerLineInserter.LIC_ABS_LOINC);
+
+    assertEquals(1, unmatched.size());
+  }
+
+  @Test
+  public void testAddResult_PdwSd_And_PdwCv_AreIndependent() {
+    // PDW is always sent as two separate OBX segments; both must be handled.
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    List<AnalyzerResults> matched = new ArrayList<>();
+    List<AnalyzerResults> unmatched = new ArrayList<>();
+
+    impl.addResult(
+        matched,
+        unmatched,
+        "NM",
+        "19.8",
+        "ACC009",
+        false,
+        "fL",
+        ErbaHematologyAnalyzerLineInserter.PDW_SD_LOINC);
+    impl.addResult(
+        matched,
+        unmatched,
+        "NM",
+        "18.5",
+        "ACC009",
+        false,
+        "%",
+        ErbaHematologyAnalyzerLineInserter.PDW_CV_LOINC);
+
+    assertEquals(2, unmatched.size());
+  }
+
+  @Test
+  public void testAddResult_MentzerIndex_Handled() {
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    List<AnalyzerResults> matched = new ArrayList<>();
+    List<AnalyzerResults> unmatched = new ArrayList<>();
+
+    impl.addResult(
+        matched,
+        unmatched,
+        "NM",
+        "13.78",
+        "ACC010",
+        false,
+        "",
+        ErbaHematologyAnalyzerLineInserter.MENTZER_LOINC);
+
+    assertEquals(1, unmatched.size());
+    assertEquals("13.78", unmatched.get(0).getResult());
+  }
+
+  // IS-type metadata segments
+
+  @Test
+  public void testAddResult_MetadataSegment_TakeMode_RoutesToNotMatched() {
+    // OBX segments like Take Mode (02001), Test Mode (02003) etc. should
+    // silently land in notMatchedResults — they are never clinical results.
+    ErbaHematologyAnalyzerLineInserter impl = instanceWithMock();
+    List<AnalyzerResults> matched = new ArrayList<>();
+    List<AnalyzerResults> unmatched = new ArrayList<>();
+
+    impl.addResult(matched, unmatched, "IS", "O", "ACC011", false, "", "02001");
+
+    assertEquals(0, matched.size());
+    assertEquals(1, unmatched.size());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <module>./analyzers/GenericHL7</module>
     <module>./analyzers/GenericFile</module>
     <module>./analyzers/StagoSTart4</module>
+    <module>./analyzers/ErbaHematology</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
### Analyzer Information

| Field        | Value                              |
|--------------|------------------------------------|
| Manufacturer | Erba Mannheim |
| Models       | H360, H560, ELite 580              |
| Category     | Hematology                         |
| Protocol     | HL7 v2.3.1                         |
| Transport    | TCP/IP with MLLP framing           |

---

### Overview

This plugin integrates the Erba Mannheim hematology analyzer family with OpenELIS
Global. All three models share the same HL7 v2.3.1 message structure but differ
in differential capability:

- **H360** - 3-part differential (GRAN/MID/LYM), 22 parameters
- **H560** - 5-part differential (NEU/LYM/MON/EOS/BAS), 26 parameters  
- **ELite 580** - 5-part differential with extended parameters (ALY, LIC), 
  26 parameters, 80 samples/hour with autoloader

A single plugin handles all three models. The correct parameter set is used
automatically based on what the instrument sends. No other configuration required.

---

### Protocol Details

The instrument initiates a persistent TCP connection to the LIS server and
transmits results as HL7 v2.3.1 ORU^R01 messages with MLLP framing:

- Start block: `0x0B` (VT)
- End block: `0x1C 0x0D` (FS + CR)
- Encoding: UTF-8 (`MSH-18 = UNICODE`)
- Accession number: OBR-3 (Filler Order Number)
- QC detection: OBR-13 non-empty → flagged as control sample

---

### Parameters Supported

| Group | Parameters |
|-------|-----------|
| WBC | WBC |
| 5-part diff % | NEU%, LYM%, MON%, EOS%, BAS% |
| 5-part diff # | NEU#, LYM#, MON#, EOS#, BAS# |
| 3-part diff % | GRAN%, MID%, LYM% |
| 3-part diff # | GRAN#, MID#, LYM# |
| RBC series | RBC, HGB, HCT, MCV, MCH, MCHC, RDW-CV, RDW-SD |
| RBC indices | Mentzer Index, RDW Index |
| Platelets | PLT, MPV, PDW-SD, PDW-CV, PDW, PCT, P-LCR, P-LCC |
| Extended (ELite 580) | ALY#, ALY%, LIC#, LIC% |

---

### Implementation Notes

- Uses **lazy initialization** pattern throughout - no static Spring context
  calls, fully unit testable without application context
- IS-type metadata OBX segments (Take Mode, Blood Mode, Test Mode, Ref Group,
  Remark) and alarm flag segments (13xxx codes) are silently routed to
  `notMatchedResults` - no errors, no data loss
- ED-type OBX segments (Base64-encoded histograms and scattergrams) are skipped
  at the servlet level before reaching the inserter
- PDW is handled as three separate constants (`PDW`, `PDW-SD`, `PDW-CV`) to
  cover both the single-parameter brochure spec and the two-parameter behaviour
  observed in real messages

---

### Known Deployment Notes

- Tests not present in the default OpenELIS test catalog (GRAN%, MID%, PDW-SD,
  PDW-CV, Mentzer Index, RDW Index, ALY, LIC, Plateletcrit, P-LCR, P-LCC etc.)
  will log a warning at startup but will not prevent the plugin from loading.
  These tests must be configured in the OpenELIS test catalog by the deploying
  site before results for those parameters will be stored.
- Mentzer Index and RDW Index observed in real H360 and ELite 580 messages but
  not listed in official brochure parameter specs - included as they appear in
  production data from India deployments.

---

### Region Context

This plugin was developed and validated against real HL7 messages captured from
H360, H560, and ELite 580 instruments deployed in clinical laboratories in
**India**. The Erba Mannheim hematology range is widely used across
South Asia and Africa in small-to-mid-size laboratories.

---

### Example Messages

Representative HL7 messages for each model (all patient details fictitious)
are included in `./ORU_R01.md`.

---

### Testing

Test coverage includes:
- Constructor does not require Spring context (lazy init verification)
- `insert()` always returns false (HL7 servlet path only)
- Unknown and null LOINC codes route to `notMatchedResults` without exception
- Result value, units, accession number stored correctly on `AnalyzerResults`
- QC control flag propagated correctly from OBR-13
- `completeDate` is set on every result
- H360-specific parameters (GRAN%, MID#) handled correctly
- ELite 580-specific parameters (LIC#) handled correctly
- PDW-SD and PDW-CV treated as independent parameters
- Mentzer Index handled correctly
- IS-type metadata segments (Take Mode etc.) silently ignored

