### PR TITLE
fix(GenericHL7): extract MSH-3+MSH-4 for analyzer pattern matching

### DIFF
--- a/analyzers/GenericHL7/src/main/java/org/openelisglobal/plugins/analyzer/generichl7/GenericHL7Analyzer.java
+++ b/analyzers/GenericHL7/src/main/java/org/openelisglobal/plugins/analyzer/generichl7/GenericHL7Analyzer.java
@@ -132,7 +132,10 @@ public class GenericHL7Analyzer implements AnalyzerImporterPlugin {
       return false;
     }
 
-    // Query database for matching analyzer with identifier pattern
+    // Query database for matching analyzer with identifier pattern.
+    // Pass both MSH-3 alone and MSH-3+MSH-4 combined so patterns like
+    // "MINDRAY.*BC.?5380" can match "MINDRAY-BC-5380" while simpler
+    // patterns like "SYSMEX" can match MSH-3 alone.
     try {
       AnalyzerService analyzerService = SpringContext.getBean(AnalyzerService.class);
 
@@ -142,7 +145,15 @@ public class GenericHL7Analyzer implements AnalyzerImporterPlugin {
         return false;
       }
 
-      Optional<Analyzer> analyzer = analyzerService.findByIdentifierPatternMatch(msh3);
+      // Build candidate identifiers: MSH-3 alone + MSH-3+MSH-4 combined
+      java.util.List<String> identifiers = new java.util.ArrayList<>();
+      identifiers.add(msh3);
+      String msh4 = parseMsh4SendingFacility(lines);
+      if (!StringUtils.isBlank(msh4)) {
+        identifiers.add(msh3.trim() + "-" + msh4.trim());
+      }
+
+      Optional<Analyzer> analyzer = analyzerService.findByIdentifierPatternMatch(identifiers);
       if (analyzer.isPresent()) {
         // Store matched analyzer for getAnalyzerLineInserter()
         matchedAnalyzer.set(analyzer.get());
@@ -150,7 +161,7 @@ public class GenericHL7Analyzer implements AnalyzerImporterPlugin {
         LogEvent.logDebug(
             this.getClass().getSimpleName(),
             "isTargetAnalyzer",
-            "Matched MSH-3 '" + msh3 + "' to analyzer: " + analyzer.get().getName());
+            "Matched identifiers " + identifiers + " to analyzer: " + analyzer.get().getName());
         return true;
       }
 
@@ -228,6 +239,28 @@ public class GenericHL7Analyzer implements AnalyzerImporterPlugin {
         // fields[0]=MSH, [1]=encoding, [2]=MSH-3, [3]=MSH-4
         if (fields.length > 2 && !StringUtils.isBlank(fields[2])) {
           return fields[2].trim();
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Parse MSH-4 (sending facility) from HL7 MSH segment.
+   *
+   * <p>Used together with MSH-3 to build a combined identifier (e.g. "MINDRAY-BC-5380") for
+   * pattern matching against analyzer.identifier_pattern.
+   *
+   * @param lines HL7 message segment lines
+   * @return MSH-4 sending facility string, or null if not found
+   */
+  private String parseMsh4SendingFacility(List<String> lines) {
+    for (String line : lines) {
+      if (line != null && line.startsWith("MSH|")) {
+        String[] fields = line.split("\\|");
+        // fields[0]=MSH, [1]=encoding, [2]=MSH-3, [3]=MSH-4
+        if (fields.length > 3 && !StringUtils.isBlank(fields[3])) {
+          return fields[3].trim();
         }
       }
     }


### PR DESCRIPTION
## Summary
`isTargetAnalyzer()` was only passing MSH-3 to `findByIdentifierPatternMatch`, so patterns like `MINDRAY.*BC.?5380` couldn't match when MSH-3 is just `MINDRAY`.

Now extracts MSH-4 (sending facility) and passes both identifiers: `["MINDRAY", "MINDRAY-BC-5380"]`. The existing `List<String>` overload in `AnalyzerServiceImpl` scores by match length, so the combined identifier wins for device-specific patterns while simpler patterns still work.

## Linked PRs
- Core fix: DIGI-UW/OpenELIS-Global-2#3035 (passes X-Analyzer-Id to HL7AnalyzerReader)
- Mock server: DIGI-UW/analyzer-mock-server#18 (strict HL7 MLLP push)

## Test plan
- [ ] BC-5380 HL7 message with MSH-3=MINDRAY, MSH-4=BC-5380 matches pattern `MINDRAY.*BC.?5380`
- [ ] Sysmex HL7 with MSH-3=SYSMEX, MSH-4=LAB still matches pattern `SYSMEX`
- [ ] Unknown MSH-3 returns false

🤖 Generated with [Claude Code](https://claude.com/claude-code)