### PR TITLE
fix(GenericHL7): declare commons-lang3 dependency

### DIFF
--- a/analyzers/GenericHL7/pom.xml
+++ b/analyzers/GenericHL7/pom.xml
@@ -24,6 +24,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.18.0</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## Summary
- declare org.apache.commons:commons-lang3 in the GenericHL7 module POM
- fixes the module dependency declaration for existing StringUtils usage

## Verification
- git diff --check
- Not run: mvn -pl ./analyzers/GenericHL7 -am -DskipTests -Dmaven.test.skip=true package (mvn is not installed in this environment)